### PR TITLE
Minor tweaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'faraday', '~> 0.14'
 
-gem 'govuk_tech_docs'
+gem 'govuk_tech_docs', '~> 1.1'
 
 group :test do
   gem 'rspec', '~> 3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.1)
     ffi (1.9.23)
-    govuk_tech_docs (1.0.0)
+    govuk_tech_docs (1.1.0)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.7.0)
       middleman-compass (>= 4.0.0)
@@ -176,7 +176,7 @@ PLATFORMS
 
 DEPENDENCIES
   faraday (~> 0.14)
-  govuk_tech_docs
+  govuk_tech_docs (~> 1.1)
   rspec (~> 3.7)
   webmock (~> 3.3)
 

--- a/source/documentation/_testing.md
+++ b/source/documentation/_testing.md
@@ -20,7 +20,7 @@ If you need to [smoke test](https://www.gov.uk/service-manual/technology/deployi
 
 The smoke test phone numbers and email addresses will validate the request and simulate a successful response, but won’t send a real message, produce a delivery receipt or persist the notification to the database.
 
-You can use these smoke test numbers and addresses with any [type of API key](/#api-keys).
+You can use these smoke test numbers and addresses with any [type of API key](#api-keys).
 
 You can smoke test all GOV.UK Notify API client functions except:
 
@@ -31,4 +31,4 @@ You cannot use the smoke test phone numbers or email address with these function
 
 ## Other testing
 
-You must use a [test API key](/#test) to do non-smoke testing such as performance or integration testing. You can use any non-smoke testing phone numbers or email addresses. You don’t need a specific GOV.UK Notify testing account.
+You must use a [test API key](#test) to do non-smoke testing such as performance or integration testing. You can use any non-smoke testing phone numbers or email addresses. You don’t need a specific GOV.UK Notify testing account.


### PR DESCRIPTION
* Fixed internal links by removing the leading `\`
* Pinned the version of the `govuk_tech_docs` gem so that we can be certain about which version is in use.