### PR TITLE
Fetch client DOCUMENTATION.md files, not README.md files

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -2,7 +2,7 @@ require 'faraday'
 
 class ExternalDoc
   def self.fetch(repository: )
-    url = "https://raw.githubusercontent.com/#{repository}/master/README.md"
+    url = "https://raw.githubusercontent.com/#{repository}/master/DOCUMENTATION.md"
 
     response = Faraday.get(url)
 

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalDoc do
     let(:repository) { 'alphagov/client-library' }
 
     before do
-      stub_request(:get, "https://raw.githubusercontent.com/#{repository}/master/README.md").
+      stub_request(:get, "https://raw.githubusercontent.com/#{repository}/master/DOCUMENTATION.md").
         to_return(body: File.read('spec/fixtures/markdown.md'))
     end
 


### PR DESCRIPTION
We now want to display the contents of the `DOCUMENTATION.md` file for each client, instead of the contents of the `README.md` for each client.