### PR TITLE
Add Makefile command to run the app locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ generate-manifest:
 generate-tech-docs-yml:
 	@erb config/tech-docs.yml.erb > config/tech-docs.yml
 
+.PHONY: development
+development: ## Set environment to development
+	$(eval export ROUTE='localhost:4567')
+	$(eval export HOST='http://localhost:4567')
+	@true
+
 .PHONY: preview
 preview: ## Set environment to preview
 	$(eval export CF_SPACE=preview)
@@ -27,12 +33,16 @@ production: ## Set environment to production
 	$(eval export HOST='https://docs.notifications.service.gov.uk')
 	@true
 
+.PHONY: run-in-development
+run-in-development: development generate-tech-docs-yml ## Runs the app in development
+	bundle exec middleman server
+
 .PHONY: generate-build-files
-generate-build-files:
+generate-build-files: generate-tech-docs-yml ## Generates the build files
 	bundle exec middleman build
 
 .PHONY: cf-deploy
-cf-deploy: generate-manifest generate-tech-docs-yml generate-build-files ## Deploys the app to Cloud Foundry
+cf-deploy: generate-manifest generate-build-files ## Deploys the app to Cloud Foundry
 	$(if ${CF_ORG},,$(error Must specify CF_ORG))
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	cf target -o ${CF_ORG} -s ${CF_SPACE}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ access it if they are given the link.
 Type the following to start the server:
 
 ```
-bundle exec middleman server
+make run-in-development
 ```
 
 If all goes well something like the following output will be displayed:


### PR DESCRIPTION
It is no longer possible to run the app locally with`bundle exec middleman server`
because changes made in https://github.com/alphagov/notifications-tech-docs/pull/7 mean that `tech-docs.yml` either won't exist or may not be up to date.

The new Makefile command to run the app ensures that `tech-docs.yml` is
created and then runs `bundle exec middleman server`.