### PR TITLE
Add docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.4.4-slim
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
+RUN \
+	echo "Install Debian packages" \
+	&& ([ -z "$HTTP_PROXY" ] || echo "Acquire::http::Proxy \"${HTTP_PROXY}\";" > /etc/apt/apt.conf.d/99HttpProxy) \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		curl \
+		g++ \
+		gcc \
+		git \
+		make \
+	&& echo "Clean up" \
+	&& rm -rf /var/lib/apt/lists/* /tmp/*
+
+WORKDIR /var/project
+COPY Gemfile* /var/project/
+RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'faraday', '~> 0.14'
 gem 'govuk-lint', '~> 3.7'
 gem 'govuk_tech_docs', '~> 1.1'
+gem 'therubyracer', '~> 0.12.3'
 
 group :test do
   gem 'rspec', '~> 3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     kramdown (1.16.2)
+    libv8 (3.16.14.19-x86_64-linux)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -149,6 +150,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.3.4)
+    ref (2.0.0)
     rouge (2.2.1)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -183,6 +185,9 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -204,7 +209,8 @@ DEPENDENCIES
   govuk-lint (~> 3.7)
   govuk_tech_docs (~> 1.1)
   rspec (~> 3.7)
+  therubyracer (~> 0.12.3)
   webmock (~> 3.3)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ generate-build-files: generate-tech-docs-yml ## Generates the build files
 	bundle exec middleman build
 
 .PHONY: cf-deploy
-cf-deploy: generate-manifest generate-build-files ## Deploys the app to Cloud Foundry
+cf-deploy: generate-manifest ## Deploys the app to Cloud Foundry
+	@[ ! -d ./build ]; echo "Build files don't exist - Generate the build files"; exit 1;
 	$(if ${CF_ORG},,$(error Must specify CF_ORG))
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	cf target -o ${CF_ORG} -s ${CF_SPACE}
@@ -58,6 +59,7 @@ cf-deploy: generate-manifest generate-build-files ## Deploys the app to Cloud Fo
 	# get the new GUID, and find all crash events for that. If there were any crashes we will abort the deploy.
 	[ $$(cf curl "/v2/events?q=type:app.crash&q=actee:$$(cf app --guid ${CF_APP})" | jq ".total_results") -eq 0 ]
 	cf delete -f ${CF_APP}-rollback
+	rm -rf ./build/
 
 .PHONY: test-with-docker
 test-with-docker: prepare-docker-runner-image ## Build inside a Docker container

--- a/script/run_tests.sh
+++ b/script/run_tests.sh
@@ -20,7 +20,7 @@ function display_result {
   fi
 }
 
-bundle exec govuk-lint-ruby
+bundle exec govuk-lint-ruby app spec
 display_result $? 1 "Code style check"
 
 bundle exec rspec


### PR DESCRIPTION
#### Add Dockerfile and related make targets


#### Add `therubyracer` dependency

Builds in docker would fail without it because they could not find
a Javascript runtime.


#### Decouple cf-deploy target from generating build files

The point of using docker is so that we don't have to install ruby and
its dependencies on our machine.

This commit removes the link between the `cf-deploy` target
and the `generate-build-files` one and instead checks if the build
directory exists before the deployment and removes it in the end to
ensure that we always have a fresh copy of the data.