### PR TITLE
Add support for multiple build directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ generate-build-files: generate-tech-docs-yml ## Generates the build files
 
 .PHONY: cf-deploy
 cf-deploy: generate-manifest ## Deploys the app to Cloud Foundry
-	@[ ! -d ./build ]; echo "Build files don't exist - Generate the build files"; exit 1;
 	$(if ${CF_ORG},,$(error Must specify CF_ORG))
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	cp -r build-${CF_SPACE} build
 	cf target -o ${CF_ORG} -s ${CF_SPACE}
 	@cf app --guid ${CF_APP} || exit 1
 	cf rename ${CF_APP} ${CF_APP}-rollback
@@ -87,6 +87,7 @@ build-with-docker: prepare-docker-runner-image ## Build inside a Docker containe
 		-e NO_PROXY="${NO_PROXY}" \
 		${DOCKER_BUILDER_IMAGE_NAME} \
 		make ${CF_SPACE} generate-build-files
+		mv build build-${CF_SPACE}
 
 .PHONY: prepare-docker-runner-image
 prepare-docker-runner-image: ## Prepare the Docker builder image


### PR DESCRIPTION
Rename `build/` directory to `build-CF_SPACE/` which will allow to
generate separate outputs for the different environments.

During the master build, we will generate the output for both preview
and production in different directories and add them to the zip file to
be deployed.

When deploying we copy the `build-CF_SPACE/` to `build/`, run the
deployment and then remove it again.