### PR TITLE
Change link location of 'Documentation' link in header

### DIFF
--- a/config/tech-docs.yml.erb
+++ b/config/tech-docs.yml.erb
@@ -12,7 +12,7 @@ header_links:
   Support: https://www.notifications.service.gov.uk/support
   Features: https://www.notifications.service.gov.uk/features
   Pricing: https://www.notifications.service.gov.uk/pricing
-  Documentation: /
+  Documentation: https://www.notifications.service.gov.uk/documentation
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:


### PR DESCRIPTION
Changed the Documentation link at the top of the page to link to
https://www.notifications.service.gov.uk/documentation instead of the
homepage of the docs site. Since only the Python docs will be live
initially, we want to carry on linking to the existing documentation
page.