### PR TITLE
Add sentence below table in callbacks section

### DIFF
--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -18,7 +18,7 @@ To do this, log into your GOV.UK Notify account, go to __API integration__ and s
 
 If your service receives text messages in Notify, Notify can forward them to your callback URL as soon as they arrive.
 
-Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://govuk.slack.com/messages/C0AC2LX7E) to enable "Receive text messages" for your service.
+Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) to enable "Receive text messages" for your service.
 
 The callback message is formatted in JSON. The key, description and format of the callback message arguments will be:
 
@@ -27,13 +27,13 @@ The callback message is formatted in JSON. The key, description and format of th
 |`id`|Notify’s id for the status receipts|UUID|
 |`reference`|The reference sent by the service|12345678|
 |`to`|The email address of the recipient|hello@gov.uk|
-|`status`|The status of the notification|delivered / permanent-failure / temporary-failure / technical-failure| 
+|`status`|The status of the notification|delivered / permanent-failure / temporary-failure / technical-failure|
 |`created_at`|The time the service sent the request|2017-05-14T12:15:30.000000Z|
 |`completed_at`|The last time the status was updated|2017-05-14T12:15:30.000000Z|
 |`sent_at`|The time the notification was sent|2017-05-14T12:15:30.000000Z or nil|
 |`notification_type`|The notification type|email / sms / letter|
 
-Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://govuk.slack.com/messages/C0AC2LX7E) if you have any questions.
+Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) if you have any questions.
 
 ## For delivery receipts
 

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -33,6 +33,8 @@ The callback message is formatted in JSON. The key, description and format of th
 |`sent_at`|The time the notification was sent|2017-05-14T12:15:30.000000Z or nil|
 |`notification_type`|The notification type|email / sms / letter|
 
+Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://govuk.slack.com/messages/C0AC2LX7E) if you have any questions.
+
 ## For delivery receipts
 
 When you send an email or text message through Notify, Notify will send a receipt to your callback URL with the status of the message. This is an automated method to get the status of messages.  

--- a/source/documentation/_support.md
+++ b/source/documentation/_support.md
@@ -5,4 +5,4 @@ Report any problems via the [GOV.UK Notify support page](https://www.notificatio
 You can also:
 
 - check the [GOV.UK Notify system status page](https://status.notifications.service.gov.uk/)
-- ask the team on the GOV.UK Notify [Slack channel](https://govuk.slack.com/messages/C0AC2LX7E)
+- ask the team on the GOV.UK Notify [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify)


### PR DESCRIPTION
Having a table followed by a heading was causing the table to be
displayed at the bottom of the page. Adding a sentence below the table
is a quick fix to make the table display in its proper location.