### PR TITLE
Upgrade tech docs Gem to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'faraday', '~> 0.14'
 gem 'govuk-lint', '~> 3.7'
-gem 'govuk_tech_docs', '~> 1.1'
+gem 'govuk_tech_docs', '~> 1.3'
 gem 'therubyracer', '~> 0.12.3'
 
 group :test do

--- a/source/client_template.html.md.erb
+++ b/source/client_template.html.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Client documentation - GOV.UK Notify
+parent: https://www.notifications.service.gov.uk/documentation
 ---
 
 <%= ExternalDoc.fetch(repository: repo) %>


### PR DESCRIPTION
Adds support for setting a page’s parent, which means we can highlight ‘Documentation’ in the navigation.

---

Depends on:
- [x] https://github.com/alphagov/tech-docs-gem/pull/24