### PR TITLE
Improve documentation about callbacks

### DIFF
--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -14,29 +14,37 @@ You must provide:
 
 To do this, log into your GOV.UK Notify account, go to __API integration__ and select __Callbacks__.
 
-## For received text messages
-
-If your service receives text messages in Notify, Notify can forward them to your callback URL as soon as they arrive.
-
-Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) to enable "Receive text messages" for your service.
-
-The callback message is formatted in JSON. The key, description and format of the callback message arguments will be:
-
-|Key|Description|Format|
-|:---|:---|:---|
-|`id`|Notify’s id for the status receipts|UUID|
-|`reference`|The reference sent by the service|12345678|
-|`to`|The email address of the recipient|hello@gov.uk|
-|`status`|The status of the notification|delivered / permanent-failure / temporary-failure / technical-failure|
-|`created_at`|The time the service sent the request|2017-05-14T12:15:30.000000Z|
-|`completed_at`|The last time the status was updated|2017-05-14T12:15:30.000000Z|
-|`sent_at`|The time the notification was sent|2017-05-14T12:15:30.000000Z or nil|
-|`notification_type`|The notification type|email / sms / letter|
-
-Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) if you have any questions.
-
 ## For delivery receipts
 
 When you send an email or text message through Notify, Notify will send a receipt to your callback URL with the status of the message. This is an automated method to get the status of messages.  
 
 This functionality works with test API keys, but does not work with smoke testing phone numbers or email addresses.
+
+The callback message is formatted in JSON. The key, description and format of the callback message arguments will be:
+
+|Key | Description | Format|
+|:---|:---|:---|
+|`id` | Notify’s id for the status receipts | UUID|
+|`reference` | The reference sent by the service | 12345678|
+|`to` | The email address or phone number of the recipient | hello@gov.uk or 07700912345|
+|`status` | The status of the notification | `delivered`, `permanent-failure`, `temporary-failure` or `technical-failure`|
+|`created_at` | The time the service sent the request | `2017-05-14T12:15:30.000000Z`|
+|`completed_at` | The last time the status was updated | `2017-05-14T12:15:30.000000Z` or nil|
+|`sent_at` | The time the notification was sent | `2017-05-14T12:15:30.000000Z` or nil|
+|`notification_type` | The notification type | `email` or `sms`|
+
+## For received text messages
+
+If your service receives text messages in Notify, Notify can forward them to your callback URL as soon as they arrive.
+
+Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) to enable receiving text messages for your service.
+
+The callback message is formatted in JSON. The key, description and format of the callback message arguments will be:
+
+|Key | Description | Format|
+|:---|:---|:---|
+|id | Notify’s id for the received message | UUID|
+|source_number | The phone number the message was sent from | 447700912345|
+|destination_number | The number the message was sent to (your number) | 07700987654|
+|message | The received message | Hello Notify!|
+|date_received | The UTC datetime that the message was received by Notify | 2017-05-14T12:15:30.000000Z|

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -43,8 +43,8 @@ The callback message is formatted in JSON. The key, description and format of th
 
 |Key | Description | Format|
 |:---|:---|:---|
-|id | Notify’s id for the received message | UUID|
-|source_number | The phone number the message was sent from | 447700912345|
-|destination_number | The number the message was sent to (your number) | 07700987654|
-|message | The received message | Hello Notify!|
-|date_received | The UTC datetime that the message was received by Notify | 2017-05-14T12:15:30.000000Z|
+|`id` | Notify’s id for the received message | UUID|
+|`source_number` | The phone number the message was sent from | 447700912345|
+|`destination_number` | The number the message was sent to (your number) | 07700987654|
+|`message` | The received message | Hello Notify!|
+|`date_received` | The UTC datetime that the message was received by Notify | 2017-05-14T12:15:30.000000Z|

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -14,7 +14,7 @@ You must provide:
 
 To do this, log into your GOV.UK Notify account, go to __API integration__ and select __Callbacks__.
 
-## For delivery receipts
+## Delivery receipts
 
 When you send an email or text message through Notify, Notify will send a receipt to your callback URL with the status of the message. This is an automated method to get the status of messages.  
 
@@ -33,7 +33,7 @@ The callback message is formatted in JSON. The key, description and format of th
 |`sent_at` | The time the notification was sent | `2017-05-14T12:15:30.000000Z` or nil|
 |`notification_type` | The notification type | `email` or `sms`|
 
-## For received text messages
+## Received text messages
 
 If your service receives text messages in Notify, Notify can forward them to your callback URL as soon as they arrive.
 


### PR DESCRIPTION
- put them above inbound callbacks (normal delivery receipts are the more commonly used feature)
- add the info about the format of inbound callbacks, and associate it with the correct section
- remove redundant line about contacting support if you have any questions (this could apply to any part of the documentation)