### PR TITLE
Make rate limits clearer

### DIFF
--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -22,4 +22,8 @@ These limits reset at midnight.
 
 If you repeatedly send text messages to the same number the phone networks will block your messages.
 
-MORE DETAIL HERE
+There is an hourly limit of:
+- 6 messages with same content
+- 20 messages with any content
+
+Beyond these limits your messages won’t be delivered.

--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -1,16 +1,25 @@
 # Limits
 
-## API rate limits
+## Rate limits
 
-There is a rate limit for requests to the API from your account. The limit is 3000 per rolling 60 second time period. This limit applies per API key type. If you exceed the limit, you will receive the `429` error `RateLimitError`.
+You’re limited to sending 3000 messages per minute.
 
-## Service limits
+This limit is calculated on a rolling basis, per API key type. If you exceed the limit, you will get a `429` error `RateLimitError`.
 
-There are limits for the number of messages sent per day. These limits depend on whether your service is live, and the API key type. Limits reset at midnight.
+## Daily limits
 
-|Service status|API key type|Daily limit|
+There’s a limit to how many messages you can send each day:
+
+|Service status|Type of API key|Daily limit|
 |:---|:---|:---|
-|Live|Team / Live|250,000|
-|Live|Test|Unlimited|
-|Trial|Team / Live|50|
-|Trial|Test|Unlimited|
+|Live|Team or live|250,000|
+|Trial|Team|50|
+|Live or trial|Test|Unlimited|
+
+These limits reset at midnight.
+
+## Phone network limits
+
+If you repeatedly send send text messages to the same phone number the phone networks will block your messages.
+
+MORE DETAIL HERE

--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -8,7 +8,7 @@ This limit is calculated on a rolling basis, per API key type. If you exceed the
 
 ## Daily limits
 
-There’s a limit to how many messages you can send each day:
+There's a limit to the number of messages you can send each day:
 
 |Service status|Type of API key|Daily limit|
 |:---|:---|:---|

--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -20,10 +20,10 @@ These limits reset at midnight.
 
 ## Phone network limits
 
-If you repeatedly send text messages to the same number the phone networks will block your messages.
+If you repeatedly send text messages to the same number the phone networks will block them.
 
-There is an hourly limit of:
+There’s an hourly limit of:
 - 6 messages with same content
 - 20 messages with any content
 
-Beyond these limits your messages won’t be delivered.
+Your messages will not be delivered if you exceed these limits.

--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -20,6 +20,6 @@ These limits reset at midnight.
 
 ## Phone network limits
 
-If you repeatedly send send text messages to the same phone number the phone networks will block your messages.
+If you repeatedly send text messages to the same number the phone networks will block your messages.
 
 MORE DETAIL HERE

--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -2,7 +2,7 @@
 
 ## Rate limits
 
-You’re limited to sending 3000 messages per minute.
+You’re limited to sending 3,000 messages per minute.
 
 This limit is calculated on a rolling basis, per API key type. If you exceed the limit, you will get a `429` error `RateLimitError`.
 


### PR DESCRIPTION
This commit proposes:
- tidying up the rate limit section so that it’s clearer and less wordy
- front loading the important information (the 3000 messages/min)
- adding some info about rate limits imposed by the phone networks, because people keep asking why their messages have started failing to be delivered