### PR TITLE
Fix list syntax

### DIFF
--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -23,6 +23,7 @@ These limits reset at midnight.
 If you repeatedly send text messages to the same number the phone networks will block them.
 
 There’s an hourly limit of:
+
 - 6 messages with same content
 - 20 messages with any content
 


### PR DESCRIPTION
Tech docs Markdown parser seems to require a newline before list.