### PR TITLE
Pin gems in the Gemfile more precisely

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'faraday', '~> 0.14'
-gem 'govuk-lint', '~> 3.7'
-gem 'govuk_tech_docs', '~> 1.3'
+gem 'faraday', '~> 0.14.0'
+gem 'govuk-lint', '~> 3.7.0'
+gem 'govuk_tech_docs', '~> 1.3.1'
 gem 'therubyracer', '~> 0.12.3'
 
 group :test do
-  gem 'rspec', '~> 3.7'
-  gem 'webmock', '~> 3.3'
+  gem 'rspec', '~> 3.7.0'
+  gem 'webmock', '~> 3.3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.6)
+    activesupport (5.0.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
@@ -11,7 +11,8 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (6.7.7.2)
       execjs
-    backports (3.11.1)
+    backports (3.11.4)
+    chronic (0.10.2)
     chunky_png (1.3.10)
     coffee-script (2.4.1)
       coffee-script-source
@@ -34,23 +35,25 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    dotenv (2.2.1)
+    dotenv (2.5.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.2.5)
+    eventmachine (1.2.7)
     execjs (2.7.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     fast_blank (1.0.0)
-    fastimage (2.1.1)
-    ffi (1.9.23)
+    fastimage (2.1.4)
+    ffi (1.9.25)
     govuk-lint (3.7.0)
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_tech_docs (1.1.0)
+    govuk_tech_docs (1.3.1)
+      activesupport
+      chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.7.0)
       middleman-compass (>= 4.0.0)
@@ -65,10 +68,11 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (0.3.7)
-    hashie (3.5.7)
+    hashie (3.6.0)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    kramdown (1.16.2)
+    kramdown (1.17.0)
+    libv8 (3.16.14.19)
     libv8 (3.16.14.19-x86_64-linux)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -127,7 +131,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
@@ -140,8 +144,8 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.1)
     public_suffix (3.0.1)
-    rack (2.0.4)
-    rack-livereload (0.3.16)
+    rack (2.0.5)
+    rack-livereload (0.3.17)
       rack
     rainbow (2.2.2)
       rake
@@ -181,7 +185,7 @@ GEM
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
     servolux (0.13.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.0)
@@ -205,12 +209,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  faraday (~> 0.14)
-  govuk-lint (~> 3.7)
-  govuk_tech_docs (~> 1.1)
-  rspec (~> 3.7)
+  faraday (~> 0.14.0)
+  govuk-lint (~> 3.7.0)
+  govuk_tech_docs (~> 1.3.1)
+  rspec (~> 3.7.0)
   therubyracer (~> 0.12.3)
-  webmock (~> 3.3)
+  webmock (~> 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
We had the `govuk_tech_docs` gem in the Gemfile as
`gem 'govuk_tech_docs', '~> 1.3.1'`. This syntax allowed the minor
version to be increased automatically to version 1.6.0 when the app
was deployed, which caused a breaking change. This commit changes the
Gemfile to pin the minor versions of all the gems to avoid the risk of
any future breaking changes.

(Some of the gems also need upgrading to the latest version, but this is best
done as a separate change.)