### PR TITLE
Revert "Bump govuk_tech_docs from 1.3.1 to 1.6.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'faraday', '~> 0.15.3'
 gem 'govuk-lint', '~> 3.9.0'
-gem 'govuk_tech_docs', '~> 1.6.3'
+gem 'govuk_tech_docs', '~> 1.3.1'
 gem 'therubyracer', '~> 0.12.3'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,14 +13,11 @@ GEM
       execjs
     backports (3.11.4)
     chronic (0.10.2)
-    chunky_png (1.3.11)
-    coderay (1.1.2)
+    chunky_png (1.3.10)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.18.1)
-      ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -33,7 +30,7 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.0.5)
     contracts (0.13.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -54,19 +51,16 @@ GEM
       rubocop (~> 0.58)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_tech_docs (1.6.3)
+    govuk_tech_docs (1.3.1)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.7.0)
       middleman-compass (>= 4.0.0)
       middleman-livereload
-      middleman-search-gds
       middleman-sprockets (~> 4.0.0)
       middleman-syntax (~> 3.0.0)
       nokogiri
-      openapi3_parser
-      pry
       redcarpet (~> 3.3.2)
     haml (5.0.4)
       temple (>= 0.8.0)
@@ -84,7 +78,6 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
-    method_source (0.9.2)
     middleman (4.2.1)
       coffee-script (~> 2.2)
       compass-import-once (= 1.0.5)
@@ -128,10 +121,6 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
-    middleman-search-gds (0.11.0a)
-      execjs (~> 2.6)
-      middleman-core (>= 3.2)
-      nokogiri (~> 1.6)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -144,8 +133,6 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    openapi3_parser (0.5.2)
-      commonmarker (~> 0.17)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.4)
@@ -156,10 +143,7 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    public_suffix (3.0.3)
+    public_suffix (3.0.1)
     rack (2.0.6)
     rack-livereload (0.3.17)
       rack
@@ -194,8 +178,6 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.29.1)
       rubocop (>= 0.58.0)
-    ruby-enum (0.7.2)
-      i18n
     ruby-progressbar (1.10.0)
     safe_yaml (1.0.4)
     sass (3.4.25)
@@ -210,7 +192,7 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
-    thor (0.20.3)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tzinfo (1.2.5)
@@ -229,7 +211,7 @@ PLATFORMS
 DEPENDENCIES
   faraday (~> 0.15.3)
   govuk-lint (~> 3.9.0)
-  govuk_tech_docs (~> 1.6.3)
+  govuk_tech_docs (~> 1.3.1)
   rspec (~> 3.8.0)
   therubyracer (~> 0.12.3)
   webmock (~> 3.4.2)


### PR DESCRIPTION
Reverts alphagov/notifications-tech-docs#34

Seems to have broken the thing that highlights the navigation as you scroll the page.