### PR TITLE
Update link to Slack channel

### DIFF
--- a/source/documentation/_support.md
+++ b/source/documentation/_support.md
@@ -5,4 +5,4 @@ Report any problems via the [GOV.UK Notify support page](https://www.notificatio
 You can also:
 
 - check the [GOV.UK Notify system status page](https://status.notifications.service.gov.uk/)
-- ask the team on the GOV.UK Notify [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify)
+- ask the team on the GOV.UK Notify [Slack channel](https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC)


### PR DESCRIPTION
Updates the link to Slack in the Support section of our Documentation to use the Notify Slack channel's unique ID.

This is needed because the current link uses the channel name, which isn't recognised. Instead of opening the Notify Slack channel, the link defaults to whatever channel the user last had open.