### PR TITLE
Use double quotes instead of single quotes in Ruby

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -1,4 +1,4 @@
-require 'faraday'
+require "faraday"
 
 class ExternalDoc
   def self.fetch(repository:)

--- a/spec/app/client_docs_spec.rb
+++ b/spec/app/client_docs_spec.rb
@@ -1,8 +1,8 @@
-require './app/client_docs'
+require "./app/client_docs"
 
 RSpec.describe ClientDocs do
-  describe '.pages' do
-    it 'returns a Page for each client' do
+  describe ".pages" do
+    it "returns a Page for each client" do
       client_pages = ClientDocs.pages
 
       expect(client_pages.count).to eq 6
@@ -12,11 +12,11 @@ RSpec.describe ClientDocs do
 end
 
 RSpec.describe ClientDocs::Page do
-  describe '#repository' do
-    it 'returns the repository name for a given client' do
-      page = ClientDocs::Page.new('ruby')
+  describe "#repository" do
+    it "returns the repository name for a given client" do
+      page = ClientDocs::Page.new("ruby")
 
-      expect(page.repository).to eq('alphagov/notifications-ruby-client')
+      expect(page.repository).to eq("alphagov/notifications-ruby-client")
     end
   end
 end

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -1,15 +1,15 @@
-require './app/external_doc'
+require "./app/external_doc"
 
 RSpec.describe ExternalDoc do
-  describe '.fetch' do
-    let(:repository) { 'alphagov/client-library' }
+  describe ".fetch" do
+    let(:repository) { "alphagov/client-library" }
 
     before do
       stub_request(:get, "https://raw.githubusercontent.com/#{repository}/master/DOCUMENTATION.md").
-        to_return(body: File.read('spec/fixtures/markdown.md'))
+        to_return(body: File.read("spec/fixtures/markdown.md"))
     end
 
-    it 'returns a GitHub page as a string' do
+    it "returns a GitHub page as a string" do
       page_contents = ExternalDoc.fetch(repository: repository)
 
       expect(page_contents).to be_a(String)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'webmock/rspec'
+require "webmock/rspec"
 
 RSpec.configure do |config|
   config.before do


### PR DESCRIPTION
This linter rule is enforced as of https://github.com/alphagov/govuk-lint/pull/124