### PR TITLE
Use bash shell when running commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 CF_ORG ?= govuk-notify
 CF_APP = notify-tech-docs
 


### PR DESCRIPTION
> On Ubuntu, /bin/sh is dash, a shell designed for fast startup and execution with only standard features.

— https://unix.stackexchange.com/a/45784

> The program used as the shell is taken from the variable `SHELL'.  If this variable is not set in your makefile, the program `/bin/sh' is used as the shell.
>
> So put SHELL := /bin/bash at the top of your makefile, and you should be good to go.

— https://stackoverflow.com/a/589300

***

Currently 

```shell
cf v3-apply-manifest notify-tech-docs -f <(make -s generate-manifest)
```

…fails with
```
/bin/sh: 1: Syntax error: "(" unexpected
```