### PR TITLE
Fix external link

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -17,7 +17,7 @@ The authorisation header is an API key that is encoded using JSON Web Tokens. Yo
 
 Refer to the:
 
-- [JSON Web Tokens website](www.jwt.io) for more information on encoding your authorisation header
+- [JSON Web Tokens website](https://jwt.io/) for more information on encoding your authorisation header
 - [API keys](#api-keys) section of this documentation for more information on API key type
 
 JSON Web Tokens have a standard header:


### PR DESCRIPTION
The JWT link was pointing to `https://docs.notifications.service.gov.uk/www.jwt.io` since the `https` wasn't included.