### PR TITLE
Remove Google Analytics tracking code

### DIFF
--- a/config/tech-docs.yml.erb
+++ b/config/tech-docs.yml.erb
@@ -15,7 +15,7 @@ header_links:
   Documentation: https://www.notifications.service.gov.uk/documentation
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: UA-75215134-1
+ga_tracking_id:
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level


### PR DESCRIPTION
The tech-docs-gem includes analytics conditionally based on testing the `ga_tracking_id` option:

https://github.com/alphagov/tech-docs-gem/blob/master/lib/source/layouts/_analytics.erb#L1

This sets it to an empty string which stops it being included.

Part of https://www.pivotaltracker.com/n/projects/1443052/stories/170379929