### PR TITLE
Give each page a unique title

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'faraday', '~> 0.17.0'
+gem 'faraday', '~> 1.0.0'
 gem 'govuk-lint', '~> 4.0.1'
 gem 'govuk_tech_docs', '~> 2.0.11'
 gem 'therubyracer', '~> 0.12.3'
 
 group :test do
   gem 'rspec', '~> 3.9.0'
-  gem 'webmock', '~> 3.7.6'
+  gem 'webmock', '~> 3.8.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    faraday (0.17.0)
+    faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     fast_blank (1.0.0)
     fastimage (2.1.7)
@@ -223,7 +223,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.0)
-    webmock (3.7.6)
+    webmock (3.8.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -232,12 +232,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  faraday (~> 0.17.0)
+  faraday (~> 1.0.0)
   govuk-lint (~> 4.0.1)
   govuk_tech_docs (~> 2.0.11)
   rspec (~> 3.9.0)
   therubyracer (~> 0.12.3)
-  webmock (~> 3.7.6)
+  webmock (~> 3.8.2)
 
 BUNDLED WITH
    1.17.2

--- a/app/client_docs.rb
+++ b/app/client_docs.rb
@@ -22,5 +22,18 @@ class ClientDocs
     def repository
       "alphagov/notifications-#{client}-client"
     end
+
+    def title
+      client_titles = {
+        "java" => "Java",
+        "net" => ".NET",
+        "node" => "Node.js",
+        "php" => "PHP",
+        "python" => "Python",
+        "ruby" => "Ruby",
+      }
+
+      "#{client_titles[client]} client documentation"
+    end
   end
 end

--- a/config.rb
+++ b/config.rb
@@ -6,6 +6,7 @@ GovukTechDocs.configure(self)
 
 ClientDocs.pages.each do |page|
   proxy "/#{page.client}.html", "client_template.html", locals: {
-    repo: page.repository
+    repo: page.repository,
+    title: page.title
   }, ignore: true
 end

--- a/config/tech-docs.yml.erb
+++ b/config/tech-docs.yml.erb
@@ -4,6 +4,7 @@ host: <%= ENV.fetch("HOST") %>
 # Header-related options
 show_govuk_logo: true
 service_name: Notify
+full_service_name: GOV.UK Notify
 service_link: https://www.notifications.service.gov.uk
 phase:
 

--- a/source/client_template.html.md.erb
+++ b/source/client_template.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Client documentation - GOV.UK Notify
+title: <%= title =>
 parent: https://www.notifications.service.gov.uk/documentation
 ---
 

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: REST API documentation - GOV.UK Notify
+title: REST API documentation
 parent: https://www.notifications.service.gov.uk/documentation
 ---
 

--- a/spec/app/client_docs_spec.rb
+++ b/spec/app/client_docs_spec.rb
@@ -19,4 +19,12 @@ RSpec.describe ClientDocs::Page do
       expect(page.repository).to eq("alphagov/notifications-ruby-client")
     end
   end
+
+  describe "#title" do
+    it "returns the title for a given client" do
+      page = ClientDocs::Page.new("node")
+
+      expect(page.title).to eq("Node.js client documentation")
+    end
+  end
 end


### PR DESCRIPTION
Titles should be unique for accessibility reasons. All of our client docs had the same page title, so this change gives them all different ones.

`full_service_name` in the config has been set to `GOV.UK Notify`. This value gets used at the end of every page title (`| GOV.UK Notify`).

**Rest API title before:**
REST API documentation - GOV.UK Notify | Notify

**Rest API title after:**
REST API documentation | GOV.UK Notify

**Client title before:**
Client documentation - GOV.UK Notify | Notify

**Client title after (using Ruby client as an example):**
Ruby client documentation | GOV.UK Notify