### PR TITLE
Rename whitelist to guest list

### DIFF
--- a/source/documentation/_api_keys.md
+++ b/source/documentation/_api_keys.md
@@ -40,15 +40,15 @@ To test failure responses with a test key, use the following numbers and address
 
 You do not have to revoke test keys.
 
-## Team and whitelist
+## Team and guest list
 
-A team and whitelist key lets you send real messages to your team members and addresses/numbers on your whitelist while your service is still in trial mode.
+A team and guest list key lets you send real messages to your team members and addresses/numbers on your guest list while your service is still in trial mode.
 
-You will get an error if you use these keys to send messages to anyone who is not on your team or your whitelist.
+You will get an error if you use these keys to send messages to anyone who is not on your team or your guest list.
 
-Messages sent with a team and whitelist key appear on your dashboard and count against your text message and email allowances.
+Messages sent with a team and guest list key appear on your dashboard and count against your text message and email allowances.
 
-You do not have to revoke team and whitelist keys.
+You do not have to revoke team and guest list keys.
 
 ## Live
 


### PR DESCRIPTION
We’re renaming the ‘Team and whitelist’ key in https://github.com/alphagov/notifications-admin/pull/3479

This commit updates the documentation to match.

We will also need to update any references to ‘whitelist’ in the individual clients’ documentation.