### PR TITLE
Make API key names consistent

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -166,7 +166,7 @@ If the request is successful, the response body is `json` with a status code of 
 
 If you are using the [test API key](#test), all your messages will come back with a `delivered` status.
 
-All messages sent using the [team and whitelist](#team-and-whitelist) or [live](#live) keys will appear on your dashboard.
+All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys will appear on your dashboard.
 
 ### Error codes
 

--- a/source/documentation/_api_keys.md
+++ b/source/documentation/_api_keys.md
@@ -3,10 +3,10 @@
 There are three different types of API keys:
 
 - test
-- team and whitelist
+- team and guest list
 - live
 
-When you set up a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). A service in trial mode can create test and team and whitelist keys. You must have a live service to create a live key.
+When you set up a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). A service in trial mode can create test and team and guest list keys. You must have a live service to create a live key.
 
 To create an API key:
 


### PR DESCRIPTION
We missed a few places when renaming 'team and whitelist' to 'team and guest list'.