### PR TITLE
Errors json key

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -168,9 +168,20 @@ If you are using the [test API key](#test), all your messages will come back wit
 
 All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys will appear on your dashboard.
 
-### Error codes
+### Errors
 
-If the request is not successful, the response body is `json`, refer to the table below for details.
+If the request is not successful, the response body is `json`, for example:
+
+```json
+{
+  "status_code": 400,
+  "errors": [
+    {"error": "BadRequestError", "message": "Can't send to this recipient using a team-only API key"}
+  ]
+}
+```
+
+Refer to the table below for the different errors you may get.
 
 |status_code|errors|How to fix|
 |:---|:---|:---|

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -172,7 +172,7 @@ All messages sent using the [team and guest list](#team-and-guest-list) or [live
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`}]`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -326,7 +326,7 @@ If the request to the client is successful, the client returns a `dict`:
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`}]`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -444,7 +444,7 @@ If the request is successful, the response body is `json` and the status code is
 
 If the request is not successful, the response body is json, refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send letters with a team API key"`<br>`}]`|Use the correct type of [API key](#api-keys).|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in  [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode).|
@@ -510,7 +510,7 @@ If the request is successful, the response body is `json` and the status code is
 
 If the request is not successful, the response body is json, refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send letters with a team API key"`<br>`}]`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`}]`|PDF file format is required|
@@ -622,7 +622,7 @@ If the request is successful, the response body is `json` and the status code is
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
@@ -742,7 +742,7 @@ If the request is successful, the response body is `json` and the status code is
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|


### PR DESCRIPTION
These are my suggested improvements based on https://govuk.zendesk.com/agent/tickets/4237728

I think it's a general improvement regardless for the REST API so people can see what the actual error response is.

If this is generally seen as a good pattern then I can roll it out for the rest of the 6 month error code sections.

Another issue I've spotted but haven't fixed as part of this is there are several missing error codes, for example missing several validation errors when sending messages.

![image](https://user-images.githubusercontent.com/7228605/93488422-3f8fed00-f8fe-11ea-8b75-651efcd2512b.png)
