### PR TITLE
Adjust heading levels while keeping the styling the same

### DIFF
--- a/config/tech-docs.yml.erb
+++ b/config/tech-docs.yml.erb
@@ -21,7 +21,7 @@ ga_tracking_id:
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level
 # headings.
-max_toc_heading_level: 2
+max_toc_heading_level: 3
 
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: true

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -4,14 +4,14 @@ This documentation is for developers interested in using the GOV.UK Notify API t
 
 You can use it to integrate directly with the API if you cannot use one of our 6 client libraries.
 
-### Base URL
+## Base URL
 ```
 https://api.notifications.service.gov.uk
 ```
 
-### Headers
+## Headers
 
-#### Authorisation header
+### Authorisation header
 
 The authorisation header is an [API key](#api-keys) that is encoded using [JSON Web Tokens](https://jwt.io/). You must include an authorisation header.
 
@@ -58,7 +58,7 @@ When you have an encoded and signed token, add that token to a header as follows
 "Authorization": "Bearer encoded_jwt_token"
 ```
 
-#### Content header
+### Content header
 
 The content header is `application/json`:
 

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -4,14 +4,14 @@ This documentation is for developers interested in using the GOV.UK Notify API t
 
 You can use it to integrate directly with the API if you cannot use one of our 6 client libraries.
 
-## Base URL
+### Base URL
 ```
 https://api.notifications.service.gov.uk
 ```
 
-## Headers
+### Headers
 
-### Authorisation header
+#### Authorisation header
 
 The authorisation header is an [API key](#api-keys) that is encoded using [JSON Web Tokens](https://jwt.io/). You must include an authorisation header.
 
@@ -58,7 +58,7 @@ When you have an encoded and signed token, add that token to a header as follows
 "Authorization": "Bearer encoded_jwt_token"
 ```
 
-### Content header
+#### Content header
 
 The content header is `application/json`:
 
@@ -66,17 +66,17 @@ The content header is `application/json`:
 "Content-type": "application/json"
 ```
 
-# Send a message
+## Send a message
 
 You can use GOV.UK Notify to send text messages, emails and letters.
 
-## Send a text message
+### Send a text message
 
 ```
 POST /v2/notifications/sms
 ```
 
-### Request body
+#### Request body
 
 ```json
 {
@@ -85,13 +85,13 @@ POST /v2/notifications/sms
 }
  ```
 
-### Arguments
+#### Arguments
 
-#### phone_number (required)
+##### phone_number (required)
 
 The phone number of the recipient of the text message. This can be a UK or international number.
 
-#### template_id (required)
+##### template_id (required)
 
 To find the template ID:
 
@@ -99,7 +99,7 @@ To find the template ID:
 1. Go to the __Templates__ page and select the relevant template.
 1. Select __Copy template ID to clipboard__.
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a dictionary with key value pairs. For example:
 
@@ -112,7 +112,7 @@ If a template has placeholder fields for personalised information such as name o
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -122,7 +122,7 @@ An identifier you can create if necessary. This reference identifies a single no
 
 You can leave out this argument if you do not have a reference.
 
-#### sms_sender_id (optional)
+##### sms_sender_id (optional)
 
 A unique identifier of the sender of the text message notification.
 
@@ -143,7 +143,7 @@ You can then either:
 
 You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.
 
-### Response
+#### Response
 
 If the request is successful, the response body is `json` with a status code of `201`:
 
@@ -168,7 +168,7 @@ If you are using the [test API key](#test), all your messages will come back wit
 
 All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys will appear on your dashboard.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 
@@ -182,13 +182,13 @@ If the request is not successful, the response body is `json`, refer to the tabl
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
-## Send an email
+### Send an email
 
 ```
 POST /v2/notifications/email
 ```
 
-### Request body
+#### Request body
 ```json
 {
   "email_address": "sender@something.com",
@@ -196,13 +196,13 @@ POST /v2/notifications/email
 }
 ```
 
-### Arguments
+#### Arguments
 
-#### email_address (required)
+##### email_address (required)
 
 The email address of the recipient.
 
-#### template_id (required)
+##### template_id (required)
 
 To find the template ID:
 
@@ -210,7 +210,7 @@ To find the template ID:
 1. Go to the __Templates__ page and select the relevant template.
 1. Select __Copy template ID to clipboard__.
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a dictionary with key value pairs. For example:
 
@@ -222,7 +222,7 @@ If a template has placeholder fields for personalised information such as name o
 ```
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -231,7 +231,7 @@ An identifier you can create if necessary. This reference identifies a single no
 ```
 You can leave out this argument if you do not have a reference.
 
-#### email_reply_to_id (optional)
+##### email_reply_to_id (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
 
@@ -251,20 +251,20 @@ For example:
 
 You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.
 
-## Send a file by email
+### Send a file by email
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-### Add contact details to the file download page
+#### Add contact details to the file download page
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Settings__ page.
 1. In the __Email__ section, select __Manage__ on the __Send files by email__ row.
 1. Enter the contact details you want to use, and select __Save__.
 
-### Add a placeholder to the template
+#### Add a placeholder to the template
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
@@ -273,7 +273,7 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 
 "Download your file at: ((link_to_file))"
 
-### Upload your file
+#### Upload your file
 
 You can upload PDF, CSV, .odt, .txt and MS Word Document files. Your file must be smaller than 2MB. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
 You’ll need to convert the file into a string that is base64 encoded.
@@ -288,7 +288,7 @@ Pass the encoded string into an object with a `file` key, and put that in the pe
 }
 ```
 
-#### CSV Files
+##### CSV Files
 
 Uploads for CSV files should set the `is_csv` flag as `true` to ensure it is downloaded as a .csv file. For example:
 
@@ -300,7 +300,7 @@ Uploads for CSV files should set the `is_csv` flag as `true` to ensure it is dow
 }
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `dict`:
 
@@ -322,7 +322,7 @@ If the request to the client is successful, the client returns a `dict`:
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 
@@ -339,7 +339,7 @@ If the request is not successful, the response body is `json`, refer to the tabl
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
-## Send a letter
+### Send a letter
 
 When you add a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). You can only send letters when your service is live.
 
@@ -353,7 +353,7 @@ To send Notify a request to go live:
 POST /v2/notifications/letter
 ```
 
-### Request body
+#### Request body
 
 ```json
 {
@@ -366,9 +366,9 @@ POST /v2/notifications/letter
 }
 ```
 
-### Arguments
+#### Arguments
 
-#### template_id (required)
+##### template_id (required)
 
 To find the template ID:
 
@@ -376,7 +376,7 @@ To find the template ID:
 1. Go to the __Templates__ page and select the relevant template.
 1. Select __Copy template ID to clipboard__.
 
-#### personalisation (required)
+##### personalisation (required)
 
 The personalisation argument always contains the following parameters for the letter recipient’s address:
 
@@ -410,7 +410,7 @@ Any other placeholder fields included in the letter template also count as requi
 }
 ```
 
-#### reference (optional)
+##### reference (optional)
 
 An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -418,7 +418,7 @@ An identifier you can create if necessary. This reference identifies a single no
 "reference":"STRING"
 ```
 
-### Response
+#### Response
 
 If the request is successful, the response body is `json` and the status code is `201`:
 
@@ -440,7 +440,7 @@ If the request is successful, the response body is `json` and the status code is
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the response body is json, refer to the table below for details.
 
@@ -457,12 +457,12 @@ If the request is not successful, the response body is json, refer to the table 
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number.|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
-## Send a precompiled letter
+### Send a precompiled letter
 
 ```
 POST /v2/notifications/letter
 ```
-### Request body
+#### Request body
 
 ```json
 {
@@ -471,13 +471,13 @@ POST /v2/notifications/letter
 }
 ```
 
-### Arguments
+#### Arguments
 
-#### reference (required)
+##### reference (required)
 
 An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
-#### pdf_file (required)
+##### pdf_file (required)
 
 The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf). You’ll need to convert the file into a string that is base64 encoded.
 
@@ -485,7 +485,7 @@ The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF let
 "content": "base64EncodedPDFFile"
 ```
 
-#### postage (optional)
+##### postage (optional)
 
 You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
 
@@ -494,7 +494,7 @@ You can choose first or second class postage for your precompiled letter. Set th
 ```
 
 
-### Response
+#### Response
 
 If the request is successful, the response body is `json` and the status code is `201`:
 
@@ -506,7 +506,7 @@ If the request is successful, the response body is `json` and the status code is
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the response body is json, refer to the table below for details.
 
@@ -521,13 +521,13 @@ If the request is not successful, the response body is json, refer to the table 
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (50) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
 
 
-# Get message status
+## Get message status
 
 Message status depends on the type of message you have sent.
 
 You can only get the status of messages that are 7 days old or newer.
 
-## Status - email
+### Status - email
 
 |Status|Information|
 |:---|:---|
@@ -537,7 +537,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again."|
 
 
-## Status - text message
+### Status - text message
 
 |Status|Information|
 |:---|:---|
@@ -548,7 +548,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
 
-## Status - letter
+### Status - letter
 
 |Status|information|
 |:---|:---|
@@ -556,7 +556,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Accepted|GOV.UK Notify has sent the letter to the provider to be printed.|
 |Received|The provider has printed and dispatched the letter.|
 
-## Status - precompiled letter
+### Status - precompiled letter
 
 |Status|information|
 |:---|:---|
@@ -564,15 +564,15 @@ You can only get the status of messages that are 7 days old or newer.
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf) for more information.|
 
-## Get the status of one message
+### Get the status of one message
 
 ```
 GET /v2/notifications/{notification_id}
 ```
 
-### Query parameters
+#### Query parameters
 
-#### notification_id (required)
+##### notification_id (required)
 
 The ID of the notification. You can find the notification ID in the response to the [original notification method call](#get-the-status-of-one-message-response).
 
@@ -585,7 +585,7 @@ You can filter the returned messages by including the following optional paramet
 - [`reference`](#get-the-status-of-multiple-messages-arguments-reference-optional)
 - [`older_than`](#older-than-optional)
 
-### Response
+#### Response
 
 If the request is successful, the response body is `json` and the status code is `200`:
 
@@ -618,7 +618,7 @@ If the request is successful, the response body is `json` and the status code is
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 
@@ -630,7 +630,7 @@ If the request is not successful, the response body is `json`, refer to the tabl
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
 
 
-## Get the status of multiple messages
+### Get the status of multiple messages
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
@@ -640,7 +640,7 @@ You can only get the status of messages that are 7 days old or newer.
 GET /v2/notifications
 ```
 
-#### All messages
+##### All messages
 
 This will return all your messages with statuses. They will display in pages of up to 250 messages each.
 
@@ -651,11 +651,11 @@ You can filter the returned messages by including the following optional argumen
 - [`reference`](#get-the-status-of-multiple-messages-arguments-reference-optional)
 - [`older_than`](#older-than-optional)
 
-### Arguments
+#### Arguments
 
 You can omit any of these arguments to ignore these filters.
 
-#### template_type (optional)
+##### template_type (optional)
 
 You can filter by:
 
@@ -663,7 +663,7 @@ You can filter by:
 * `sms`
 * `letter`
 
-#### status (optional)
+##### status (optional)
 
 You can filter by each:
 
@@ -674,7 +674,7 @@ You can filter by each:
 
 You can leave out this argument to ignore this filter.
 
-#### reference (optional)
+##### reference (optional)
 
 An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -682,7 +682,7 @@ An identifier you can create if necessary. This reference identifies a single no
 "reference": "STRING"
 ```
 
-#### older_than (optional)
+##### older_than (optional)
 
 Input the ID of a notification into this argument. If you use this argument, the method returns the next 250 received notifications older than the given ID.
 
@@ -694,11 +694,11 @@ If you leave out this argument, the method returns the most recent 250 notificat
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty response.
 
-### Response
+#### Response
 
 If the request is successful, the response body is `json` and the status code is `200`.
 
-#### All messages
+##### All messages
 
 ```json
 {
@@ -738,7 +738,7 @@ If the request is successful, the response body is `json` and the status code is
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the response body is `json`, refer to the table below for details.
 

--- a/source/documentation/_api_keys.md
+++ b/source/documentation/_api_keys.md
@@ -1,4 +1,4 @@
-# API keys
+## API keys
 
 There are three different types of API keys:
 
@@ -16,7 +16,7 @@ To create an API key:
 1. Select __Create an API key__.
 
 
-## Test
+### Test
 
 Use a test key to test the performance of your service and its integration with GOV.UK Notify.
 
@@ -40,7 +40,7 @@ To test failure responses with a test key, use the following numbers and address
 
 You do not have to revoke test keys.
 
-## Team and guest list
+### Team and guest list
 
 A team and guest list key lets you send real messages to your team members and addresses/numbers on your guest list while your service is still in trial mode.
 
@@ -50,7 +50,7 @@ Messages sent with a team and guest list key appear on your dashboard and count 
 
 You do not have to revoke team and guest list keys.
 
-## Live
+### Live
 
 You can only create live keys once your service is live. You can use live keys to send messages to anyone.
 

--- a/source/documentation/_architecture.md
+++ b/source/documentation/_architecture.md
@@ -1,13 +1,13 @@
-# API architecture
+## API architecture
 
-## Send a message
+### Send a message
 
 ![](documentation/images/notify-send-a-message.png)
 
-## Get message status
+### Get message status
 
 ![](documentation/images/notify-get-message-status.png)
 
-## Get inbound messages
+### Get inbound messages
 
 ![](documentation/images/notify-get-inbound-messages.png)

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -1,11 +1,11 @@
-# Callbacks
+## Callbacks
 
 Callbacks are when GOV.UK Notify sends `POST` requests to your service. You can get callbacks when:
 
 - a text message or email you’ve sent is delivered or fails
 - your service receives a text message
 
-## Set up callbacks
+### Set up callbacks
 
 You must provide:
 
@@ -18,7 +18,7 @@ To do this:
 1. Go to the __API integration__ page.
 1. Select __Callbacks__.
 
-## Delivery receipts
+### Delivery receipts
 
 When you send an email or text message, Notify will send a receipt to your callback URL with the status of the message. This is an automated method to get the status of messages.
 
@@ -37,7 +37,7 @@ The callback message is formatted in JSON. The key, description and format of th
 |`sent_at` | The time the notification was sent | `2017-05-14T12:15:30.000000Z` or nil|
 |`notification_type` | The notification type | `email` or `sms`|
 
-## Received text messages
+### Received text messages
 
 If your service receives text messages in Notify, Notify can forward them to your callback URL as soon as they arrive.
 

--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -1,12 +1,12 @@
-# Limits
+## Limits
 
-## Rate limits
+### Rate limits
 
 You’re limited to sending 3,000 messages per minute.
 
 This limit is calculated on a rolling basis, per API key type. If you exceed the limit, you will get a `429` error `RateLimitError`.
 
-## Daily limits
+### Daily limits
 
 There’s a limit to the number of messages you can send each day:
 
@@ -18,7 +18,7 @@ There’s a limit to the number of messages you can send each day:
 
 These limits reset at midnight.
 
-## Phone network limits
+### Phone network limits
 
 If you repeatedly send text messages to the same number the phone networks will block them.
 

--- a/source/documentation/_support.md
+++ b/source/documentation/_support.md
@@ -1,4 +1,4 @@
-# Support
+## Support
 
 Report any problems via the [GOV.UK Notify support page](https://www.notifications.service.gov.uk/support).
 

--- a/source/documentation/_testing.md
+++ b/source/documentation/_testing.md
@@ -1,8 +1,8 @@
-# Testing
+## Testing
 
 All testing takes place in the production environment. There is no test environment for GOV.UK Notify.
 
-## Smoke testing
+### Smoke testing
 
 If you need to [smoke test](https://www.gov.uk/service-manual/technology/deploying-software-regularly#using-smoke-tests-after-you-deploy) your integration with Notify on a regular basis, you  must use the following smoke test phone numbers and email addresses.
 
@@ -32,6 +32,6 @@ You can smoke test all Notify API client functions except:
 
 You cannot use the smoke test phone numbers or email address with these functions because they return a fake `notification_ID`. If you need to test these functions, use a test API key and any other phone number or email.
 
-## Other testing
+### Other testing
 
 You must use a [test API key](#test) to do non-smoke testing such as performance or integration testing. You can use any non-smoke testing phone numbers or email addresses. You do not need a specific Notify testing account.

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,18 @@
 @import "govuk_tech_docs";
+
+.toc__list {
+  & li li li a:visited,
+  & li li li a:link {
+    padding-left: 10px;
+  }
+
+  & > ul > li > ul > li > a {
+    @include govuk-font(19, $weight: bold);
+  }
+}
+
+@include govuk-media-query($until: tablet) {
+    .js .toc li li li {
+        display: list-item;
+    }
+}


### PR DESCRIPTION
The docs were failing accessibility guidelines because there were multiple H1s on each page. This adjusts the heading levels to correct this.

In order to keep the docs looking the same, we then add our own styles for the table of contents. This is a temporary change until we can make a change to the tech-docs-gem to add these styles for all projects.

_This needs to be deployed at the same time as PRs to adjust the heading levels for all the client docs_