### PR TITLE
Remove references to PDF links

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -84,6 +84,6 @@ We plan to look at the redundant links and fix the accessibility issues with the
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 3 September 2020. It was last reviewed on 21 September 2020.
+This statement was prepared on 3 September 2020. It was last reviewed on 23 September 2020.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a selection of the website’s pages.

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -26,7 +26,6 @@ The text should be clear and simple to understand.
 We know some parts of this website are not fully accessible for the following reasons:
 
 - some pages have adjacent links that go to the same URL
-- some pages have links to PDF documents, and these PDFs are not fully accessible
 - there are issues caused by our Technical Documentation Template
 
 ## Feedback and contact information
@@ -60,8 +59,6 @@ The content listed below is non-accessible for the following reasons.
 
 Some pages have adjacent links that go to the same URL. This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
 
-Some pages have links to PDF documents, and these PDF documents are not fully accessible. This is not a fail under any WCAG 2.1 success criterion. We provide the information contained in these PDFs in an accessible HTML format.
-
 Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
 
 ## How we tested this website
@@ -83,7 +80,7 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to look at the redundant links and PDFs, and fix the accessibility issues with the Technical Documentation Template by the end of 2020.
+We plan to look at the redundant links and fix the accessibility issues with the Technical Documentation Template by the end of 2020.
 
 ## Preparation of this accessibility statement
 


### PR DESCRIPTION
We have published a new page on Notify with a text version of the letter specification and a link to the PDF version.

We have replaced links to the PDF in the client docs and api docs with a link to this new page.

This means we can remove the PDF issue and any references to it from the documentation accessibility statement.