### PR TITLE
Update Tech Docs Template date to March 2021

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -80,7 +80,7 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to look at the redundant links and fix the accessibility issues with the Technical Documentation Template by the end of 2020.
+We plan to look at the redundant links and fix the accessibility issues with the Technical Documentation Template by the end of March 2021.
 
 ## Preparation of this accessibility statement
 


### PR DESCRIPTION
We will not be able to fix the accessibility related issues for the tech docs template by the end of 2020.

We are extending the date to end of March 2021. Hopefully by that point we will have some developer resource to look at these issues.