### PR TITLE
Remove Excel doc type from supported list

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -281,7 +281,6 @@ You can upload the following file types:
 - CSV (.csv)
 - Text (.odt, .txt, .rtf)
 - MS Word Document (.doc, .docx)
-- Excel Document (.xlsx)
 
 Your file must be smaller than 2MB. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
 You’ll need to convert the file into a string that is base64 encoded.


### PR DESCRIPTION
This is no longer supported [1].

[1]: https://github.com/alphagov/document-download-api/pull/164