### PR TITLE
Add template accessibility issues to our statement

### DIFF
--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -23,7 +23,9 @@ The text should be clear and simple to understand.
 
 ## How accessible this website is
 
-We know this website is not fully accessible because some pages have adjacent links that go to the same URL.
+We know this website is not fully accessible because:
+- some pages have adjacent links that go to the same URL
+- there are issues caused by our technical documentation template
 
 ## Feedback and contact information
 

--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for GOV.UK Notify’s documentation
-last_reviewed_on: 2021-03-29
+last_reviewed_on: 2021-07-02
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -24,8 +24,9 @@ The text should be clear and simple to understand.
 ## How accessible this website is
 
 We know this website is not fully accessible because:
-- some pages have adjacent links that go to the same URL
-- there are [issues caused by our technical documentation template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation)
+
++ some pages have adjacent links that go to the same URL
++ there are [issues caused by our technical documentation template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation)
 
 ## Feedback and contact information
 
@@ -77,10 +78,10 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to look at the redundant links by the end of March 2021.
+We plan to look at the redundant links by the end of September 2021.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 3 September 2020. It was last reviewed on 29 March 2021.
+This statement was prepared on 3 September 2020. It was last reviewed on 2 July 2021.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a selection of the website’s pages.

--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -25,7 +25,7 @@ The text should be clear and simple to understand.
 
 We know this website is not fully accessible because:
 - some pages have adjacent links that go to the same URL
-- there are issues caused by our technical documentation template
+- there are [issues caused by our technical documentation template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation)
 
 ## Feedback and contact information
 


### PR DESCRIPTION
In April 2020, a DAC audit of GovWifi tech docs found some more accessibility
issues with the tech doc template. The GovWifi team will fix them and push
those fixes upstream but, until then we need to acknowledge them in our
accessibility statement.

These changes could do with some 👀 from @karlchillmaid.

There are 4 WCAG-related issues which must be fixed, and 2 non
WCAG-related issues that should be fixed if time permits.
The 4 WCAG-related issues are as follows:

- In some circumstances, the main page heading is automatically in focus when
  the page loads. This means keyboard-only users may miss the navigation
  elements. This fails WCAG 2.1 success criterion 2.4.3 - Focus Order.
- The navigation elements are not marked up semantically as hierarchical
  headings, which means moving through the navigation using a screen reader may
  be more difficult. This fails WCAG 2.1 success criterion 1.3.1 - Info and
  Relationships.
- There are sections of content with show / hide functionality. The
  aria-expanded attribute is not implemented correctly, so users may miss that
  menu items are expandable. This fails WCAG 2.1 success criterion 4.1.2 -
  Name, Role, Value.
- When a user searches, the search results dialogue hides the main page region
  from assistive technology. This fails WCAG 2.1 success criterion 3.2.2 - On
  Input and WCAG 2.1 success criterion 2.4.3 - Focus Order.

Once the fixes have been made, pushed upstream to the gem. We should then
pull them down and check our pages for these issues.