### PR TITLE
Update the description of the errors for the REST api docs

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -170,9 +170,9 @@ All messages sent using the [team and guest list](#team-and-guest-list) or [live
 
 #### Error codes
 
-If the request is not successful, the response body is `json`, refer to the table below for details.
+If the request is not successful, the response body is a `json` object containing a "status_code" key and an "errors" key containing a list of errors. Refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`}]`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -334,9 +334,9 @@ If the request to the client is successful, the client returns a `dict`:
 
 #### Error codes
 
-If the request is not successful, the response body is `json`, refer to the table below for details.
+If the request is not successful, the response body is a `json` object containing a "status_code" key and an "errors" key containing a list of errors. Refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`}]`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -453,9 +453,9 @@ If the request is successful, the response body is `json` and the status code is
 
 #### Error codes
 
-If the request is not successful, the response body is json, refer to the table below for details.
+If the request is not successful, the response body is a `json` object containing a "status_code" key and an "errors" key containing a list of errors. Refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send letters with a team API key"`<br>`}]`|Use the correct type of [API key](#api-keys).|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in  [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode).|
@@ -519,9 +519,9 @@ If the request is successful, the response body is `json` and the status code is
 
 #### Error codes
 
-If the request is not successful, the response body is json, refer to the table below for details.
+If the request is not successful, the response body is a `json` object containing a "status_code" key and an "errors" key containing a list of errors. Refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send letters with a team API key"`<br>`}]`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`}]`|PDF file format is required|
@@ -594,9 +594,9 @@ If the request is successful, the response body is `json` and the status code is
 
 #### Error codes
 
-If the request is not successful, the response body is `json`, refer to the table below for details.
+If the request is not successful, the response body is a `json` object containing a "status_code" key and an "errors" key containing a list of errors. Refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
@@ -714,9 +714,9 @@ If the request is successful, the response body is `json` and the status code is
 
 #### Error codes
 
-If the request is not successful, the response body is `json`, refer to the table below for details.
+If the request is not successful, the response body is a `json` object containing a "status_code" key and an "errors" key containing a list of errors. Refer to the table below for details.
 
-|status_code|message|How to fix|
+|status_code|errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|


### PR DESCRIPTION
An error response from the API looks like this:
```json
{
    "errors": [
        {
            "error": "AuthError",
            "message": "Error: Your system clock must be accurate to within 30 seconds"
        }
    ],
    "status_code": 403
}
```

The description of the errors for the REST api docs has been updated to try and reflect the structure of the JSON that is returned more accurately.

**Before**

<img width="500" alt="Screenshot 2022-09-22 at 12 47 18" src="https://user-images.githubusercontent.com/12881990/191738887-83ae4727-5159-4c89-934a-7eaed68925d2.png">

**After**

<img width="500" alt="Screenshot 2022-09-22 at 12 47 33" src="https://user-images.githubusercontent.com/12881990/191738951-e0ae908b-597b-452f-b9b8-02486b91656f.png">

This also bumps some dependencies to let this be run locally again
