### PR TITLE
Add docs for retrieving a PDF

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -936,3 +936,49 @@ If the request is not successful, the API returns `json` containing the relevant
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
+
+### Get a PDF for a letter
+
+This returns the PDF contents of a letter.
+
+```
+GET /v2/notifications/{notification_id}/pdf
+```
+
+#### Query parameters
+
+##### notification_id (required)
+
+The ID of the notification. You can find the notification ID in the response to the [original notification method call](#get-the-status-of-one-message-response).
+
+You can also find it by [signing in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and going to the __API integration__ page.
+
+#### Response
+
+If the request to the client is successful, the client will return bytes representing the raw PDF data.
+
+#### Errors
+
+If the request is not successful, the API returns `json` containing the relevant error code. For example:
+
+```json
+{
+  "status_code": 400,
+  "errors": [
+    {"error": "ValidationError", "message": "Notification is not a letter"}
+  ]
+}
+```
+
+If the request is not successful, the client will return an `HTTPError` containing the relevant error code:
+
+|error.status_code|error.message|How to fix|
+|:---|:---|:---|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
+|`400`|`[{`<br>`"error": "PDFNotReadyError",`<br>`"message": "PDF not available yet, try again later"`<br>`}]`|Wait for the letter to finish processing. This usually takes a few seconds|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|You cannot retrieve the contents of a letter that contains a virus|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "PDF not available for letters in technical-failure"`<br>`}]`|You cannot retrieve the contents of a letter in technical-failure|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Notification is not a letter"`<br>`}]`|Check that you are looking up the correct notification|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
+|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|


### PR DESCRIPTION
This endpoint is missing from the REST API docs.

![image](https://user-images.githubusercontent.com/2920760/211497800-316f7728-d822-4234-8c16-1ec5ae315d2d.png)


---

~I can't get tech-docs to run locally either natively or in docker 🤦~ edit: found a patch that lets me, but we probably need to address this properly when pulling docker images to our cache