### PR TITLE
Add new daily limits

### DIFF
--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -12,8 +12,8 @@ There’s a limit to the number of messages you can send each day:
 
 |Service status|Type of API key|Daily limit|
 |:---|:---|:---|
-|Live|Team or live|250,000|
-|Trial|Team|50|
+|Live|Team or live|<ul class="govuk-list govuk-!-font-size-16"><li>250,000 emails</li><li>250,000 text messages</li><li>20,000 letters</li></ul>|
+|Trial|Team|50 emails or text messages|
 |Live or trial|Test|Unlimited|
 
 These limits reset at midnight.


### PR DESCRIPTION
We are changing from an overall daily limit to a per-channel one, to help manage our capacity and plan for future growth.

This commit updates the documentation accordingly.

Need to use HTML here rather than pure Markdown because:
- I don’t think you can put line breaks in table cells
- We need to override the default font-size of `govuk-list` (`19px`) so it matches the rest of the content in the table (`16px`)

# Before

<img width="815" alt="image" src="https://user-images.githubusercontent.com/355079/212685258-ff5e422b-245b-4695-9578-c8583997a0d7.png">

# After

<img width="810" alt="Screenshot 2023-01-16 at 13 02 57" src="https://user-images.githubusercontent.com/355079/212685304-e1af78ab-128f-4488-9225-e1f57b6c93a5.png">

***

Depends on: 
- [x] https://github.com/alphagov/notifications-api/pull/3696