### PR TITLE
Update header links

### DIFF
--- a/config/tech-docs.yml.erb
+++ b/config/tech-docs.yml.erb
@@ -13,7 +13,7 @@ header_links:
   Support: https://www.notifications.service.gov.uk/support
   Features: https://www.notifications.service.gov.uk/features
   Pricing: https://www.notifications.service.gov.uk/pricing
-  Documentation: https://www.notifications.service.gov.uk/documentation
+  Using Notify: https://www.notifications.service.gov.uk/using-notify
 footer_links:
   Documentation Accessibility: /accessibility.html
 


### PR DESCRIPTION
This PR updates the header links so they match the new GOV.UK Notify navigation:

* Add `Using Notify`
* Remove `Documentation`