### PR TITLE
Update nginx.conf to remove Ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.2.2)
-    contracts (0.17)
+    contracts (0.16.1)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)

--- a/source/nginx.conf
+++ b/source/nginx.conf
@@ -3,13 +3,13 @@
 worker_processes 1;
 daemon off;
 
-error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+error_log ((APP_ROOT))/nginx/logs/error.log;
 events { worker_connections 1024; }
 
 http {
   charset utf-8;
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
-  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  access_log ((APP_ROOT))/nginx/logs/access.log cloudfoundry;
   default_type application/octet-stream;
   include mime.types;
   sendfile on;
@@ -31,42 +31,17 @@ http {
   server_tokens off;
 
   server {
-    listen <%= ENV["PORT"] %>;
+    listen ((PORT));
     server_name localhost;
 
     location / {
-      root <%= ENV["APP_ROOT"] %>/public;
-      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_pushstate")) %>
-      if (!-e $request_filename) {
-        rewrite ^(.*)$ / break;
-      }
-      <% end %>
+      root ((APP_ROOT))/public;
       index index.html index.htm Default.htm;
-      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
-        autoindex on;
-      <% end %>
-      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
-        auth_basic "Restricted";                                #For Basic Auth
-        auth_basic_user_file <%= auth_file %>;  #For Basic Auth
-      <% end %>
-      <% if ENV["FORCE_HTTPS"] %>
-        if ($http_x_forwarded_proto != "https") {
-          return 301 https://$host$request_uri;
-        }
-      <% end %>
-      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) %>
-        ssi on;
-      <% end %>
-      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_hsts")) %>
-        add_header Strict-Transport-Security "max-age=31536000";
-      <% end %>
     }
 
-  <% unless File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_dotfiles")) %>
     location ~ /\. {
       deny all;
       return 404;
     }
-  <% end %>
   }
 }


### PR DESCRIPTION
Ruby has been removed from the cloudfoundry static buildpack, which
means we can't use ERB in the nginx.conf file. This copies the approach
now taken here https://github.com/cloudfoundry/staticfile-buildpack/blob/a30065ddb2f5c439df9abb45309352c248db4ab8/fixtures/reverse_proxy/nginx.conf

There were lots of if statements that I haven't replaced because we
don't have the dotfiles they were checking for. We should look at the
nginx file and app set-up in more detail at some point, but this is a
quick fix to allow the app to be deployed.
