### PR TITLE
Add documentation about callback retry behaviour

### DIFF
--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -18,6 +18,12 @@ To do this:
 1. Go to the __API integration__ page.
 1. Select __Callbacks__.
 
+#### Retry behaviour
+
+If Notify sends a `POST` request to your service, but the request fails then we will retry.
+
+We will retry every 5 minutes, up to a maximum of 5 times.
+
 ### Delivery receipts
 
 When you send an email or text message, Notify will send a receipt to your callback URL with the status of the message. This is an automated method to get the status of messages.

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -18,7 +18,7 @@ To do this:
 1. Go to the __API integration__ page.
 1. Select __Callbacks__.
 
-#### Retry behaviour
+### Retry callbacks
 
 If Notify sends a `POST` request to your service, but the request fails then we will retry.
 


### PR DESCRIPTION
We receive the occasional zendesk ticket about this and it is nice to include it in our API documentation.

The answer is based on a previous response we've given to a user for this question:
https://ukgovernmentdigital.slack.com/archives/C0E1ADVPC/p1691401900692559?thread_ts=1691401318.326529&cid=C0E1ADVPC

I would like a content designer to review this please as this has been written just by myself with no content designer involved. I wasn't sure on the placement on the content (it could have been higher or lower on the page). Equally, I wasn't sure on the header class. It is an h4 but it could have been an h3 for its own section that would appear in the sidebar.

We could also elaborate on what it means for a request to fail (ie we receive a non 2xx status code response or the request times out) but I think we could try it without and instead wait for evidence that we need to add additional details.

Note, this doesn't need a pull request for any of the API clients. It will automatically be shown on the page for each of the languages.

Note, there doesn't need to be an equivalent change in the admin user interface (in my opinion) because the admin user interface points at our API documentation for all details.

<img width="1182" alt="image" src="https://github.com/alphagov/notifications-tech-docs/assets/7228605/3c07c0c6-a17f-46e6-a21f-2c51cd32b870">

<img width="706" alt="image" src="https://github.com/alphagov/notifications-tech-docs/assets/7228605/42cfafe8-8cbe-4b0e-b0c6-c38133caa6bf">

