### PR TITLE
Add missing sections to API guidance

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -262,7 +262,7 @@ You can leave out this argument if your service only has one reply-to email addr
 
 #### Response
 
-If the request to the client is successful, the client returns a `dict`:
+If the request is successful, the response body is `json` with a status code of `201`:
 
 ```json
 {
@@ -421,7 +421,7 @@ Files sent before 12 April 2023 had a longer default period of 78 weeks (18 mont
 
 #### Response
 
-If the request to the client is successful, the client returns a `dict`:
+If the request is successful, the response body is `json` with a status code of `201`:
 
 ```json
 {
@@ -1132,7 +1132,7 @@ If the request is successful, the response body is `json` and the status code is
 }
 ```
 
-If no templates exist for a template type or there no templates for a service, the client returns a `dict` with an empty `templates` list element:
+If no templates exist for a template type or there no templates for a service, the API returns a `json` object with a `templates` key for an empty array:
 
 ```json
 {
@@ -1270,7 +1270,7 @@ If the request is successful, the response body is `json` and the status code is
 
 ### Error codes
 
-If the request is not successful, the client returns an `HTTPError` containing the relevant error code.
+If the request is not successful, the API returns `json` containing the relevant error code. For example:
 
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -1221,6 +1221,10 @@ If the request is not successful, the API returns `json` containing the relevant
 
 ## Get received text messages
 
+This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.
+
+You can only get the status of messages that are 7 days old or newer.
+
 ### Enable received text messages
 
 To receive text messages:
@@ -1228,23 +1232,19 @@ To receive text messages:
 1. Go to the **Text message settings** section of the **Settings** page.
 1. Select **Change** on the **Receive text messages** row.
 
-#### Method
-
-This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.
-
-You can only get the status of messages that are 7 days old or newer.
+### Method
 
 ```
 GET /v2/received-text-messages
 ```
 
-#### Query parameters
+### Query parameters
 
-##### older_than (optional)
+#### older_than (optional)
 
 The ID of a received text message. If this is passed, the response will only list text messages received before that message.
 
-#### Response
+### Response
 
 If the request is successful, the response body is `json` and the status code is `200`.
 
@@ -1268,7 +1268,7 @@ If the request is successful, the response body is `json` and the status code is
 }
 ```
 
-#### Error codes
+### Error codes
 
 If the request is not successful, the client returns an `HTTPError` containing the relevant error code.
 

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -971,3 +971,304 @@ If the request is not successful, the client will return an `HTTPError` containi
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
+
+## Get a template
+
+### Get a template by ID
+
+#### Method
+
+This returns the latest version of the template.
+
+```python
+response = notifications_client.get_template(
+  'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
+)
+```
+
+#### Arguments
+
+##### template_id (required)
+
+The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
+
+#### Response
+
+If the request to the client is successful, the client returns a `dict`.
+
+```python
+{
+    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+    "name": "STRING", # required string - template name
+    "type": "sms / email / letter" , # required string
+    "created_at": "STRING", # required string - date and time template created
+    "updated_at": "STRING", # required string - date and time template last updated
+    "version": INTEGER,
+    "created_by": "someone@example.com", # required string
+    "body": "STRING", # required string - body of notification
+    "subject": "STRING" # required string for email - subject of email
+    "letter_contact_block": "STRING" # optional string - None if not a letter template or contact block not set
+}
+```
+
+#### Error codes
+
+If the request is not successful, the client returns an `HTTPError` containing the relevant error code:
+
+|error.status_code|error.message|How to fix|
+|:---|:---|:---|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
+|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-arguments-template-id-required)|
+
+
+### Get a template by ID and version
+
+#### Method
+
+```python
+response = notifications_client.get_template_version(
+    'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
+    'version': INTEGER,
+)
+```
+
+#### Arguments
+
+##### template_id (required)
+
+The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
+
+##### version (required)
+
+The version number of the template.
+
+#### Response
+
+If the request to the client is successful, the client returns a `dict`.
+
+```python
+{
+    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+    "name": "STRING", # required string - template name
+    "type": "sms / email / letter" , # required string
+    "created_at": "STRING", # required string - date and time template created
+    "updated_at": "STRING", # required string - date and time template last updated
+    "version": INTEGER,
+    "created_by": "someone@example.com", # required string
+    "body": "STRING", # required string - body of notification
+    "subject": "STRING" # required string for email - subject of email
+    "letter_contact_block": "STRING" # optional string - None if not a letter template or contact block not set
+}
+```
+
+#### Error codes
+
+If the request is not successful, the client returns an `HTTPError` containing the relevant error code:
+
+|error.status_code|error.message|How to fix|
+|:---|:---|:---|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
+|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-and-version-arguments-template-id-required) and [version](#version-required)|
+
+
+### Get all templates
+
+#### Method
+
+This returns the latest version of all templates.
+
+```python
+response = notifications_client.get_all_templates(
+    template_type="sms / letter / email" # optional string
+)
+```
+
+#### Arguments
+
+##### template_type (optional)
+
+If you leave out this argument, the method returns all templates. Otherwise you can filter by:
+
+- `email`
+- `sms`
+- `letter`
+
+#### Response
+
+If the request to the client is successful, the client returns a `dict`.
+
+```python
+{
+    "templates": [
+        {
+            "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+            "name": "STRING", # required string - template name
+            "type": "sms / email / letter" , # required string
+            "created_at": "STRING", # required string - date and time template created
+            "updated_at": "STRING", # required string - date and time template last updated
+            "version": NUMBER, # required string - template version
+            "created_by": "someone@example.com", # required string
+            "body": "STRING", # required string - body of notification
+            "subject": "STRING" # required string for email - subject of email
+            "letter_contact_block": "STRING" # optional string - None if not a letter template or contact block not set
+        },
+        {
+            ...another template
+        }
+    ]
+}
+```
+
+If no templates exist for a template type or there no templates for a service, the client returns a `dict` with an empty `templates` list element:
+
+```python
+{
+    "templates": []
+}
+```
+
+### Generate a preview template
+
+#### Method
+
+This generates a preview version of a template.
+
+```python
+response = notifications_client.post_template_preview(
+    template_id='f33517ff-2a88-4f6e-b855-c550268ce08a', # required UUID string
+    personalisation={
+        'KEY': 'VALUE',
+        'KEY': 'VALUE',
+        ...
+        }, # required dict - specifies template parameters
+)
+```
+
+The parameters in the personalisation argument must match the placeholder fields in the actual template. The API notification client will ignore any extra fields in the method.
+
+#### Arguments
+
+##### template_id (required)
+
+The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
+
+##### personalisation (required)
+
+If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a dictionary with key value pairs. For example:
+
+```python
+personalisation={
+    'first_name': 'Amala',
+    'application_date': '2018-01-01',
+}
+```
+
+#### Response
+
+If the request to the client is successful, you receive a `dict` response.
+
+```python
+{
+    "id": "740e5834-3a29-46b4-9a6f-16142fde533a", # required string - notification ID
+    "type": "sms / email / letter" , # required string
+    "version": INTEGER,
+    "body": "STRING", # required string - body of notification
+    "subject": "STRING" # required string for email - subject of email
+}
+```
+
+#### Error codes
+
+If the request is not successful, the client returns an `HTTPError` containing the relevant error code:
+
+|error.status_code|error.message|Notes|
+|:---|:---|:---|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Missing personalisation: [PERSONALISATION FIELD]"`<br>`}]`|Check that the personalisation arguments in the method match the placeholder fields in the template|
+|`400`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the [template ID](#generate-a-preview-template-arguments-template-id-required)|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
+
+
+## Get received text messages
+
+This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.
+
+You can only get the status of messages that are 7 days old or newer.
+
+### Get all received text messages
+
+This method returns a `<generator object>` with all received text messages.
+
+#### Method
+
+```python
+response = get_received_texts_iterator()
+```
+
+#### Response
+
+If the request to the client is successful, the client will return a `<generator object>` that will return all received text messages.
+
+```python
+<generator object NotificationsAPIClient.get_received_texts_iterator at 0x1026c7410>
+```
+
+### Get one page of received text messages
+
+This will return one page of up to 250 text messages.
+
+#### Method
+
+```python
+response = client.get_received_texts(older_than)
+```
+
+You can specify which text messages to receive by inputting the ID of a received text message into the [`older_than`](#get-one-page-of-received-text-messages-arguments-older-than-optional) argument.
+
+#### Arguments
+
+##### older_than (optional)
+
+Input the ID of a received text message into this argument. If you use this argument, the method returns the next 250 received text messages older than the given ID.
+
+```python
+older_than='740e5834-3a29-46b4-9a6f-16142fde533a' # optional string - notification ID
+```
+
+If you leave out this argument, the method returns the most recent 250 text messages.
+
+#### Response
+
+If the request to the client is successful, the client returns a `dict`.
+
+```python
+{
+  "received_text_messages":
+  [
+    {
+      "id": "STRING", # required string - ID of received text message
+      "user_number": "STRING", # required string
+      "notify_number": "STRING", # required string - receiving number
+      "created_at": "STRING", # required string - date and time template created
+      "service_id": "STRING", # required string - service ID
+      "content": "STRING" # required string - text content
+    },
+    …
+  ],
+  "links": {
+    "current": "/received-text-messages",
+    "next": "/received-text-messages?other_than=last_id_in_list"
+  }
+}
+```
+
+#### Error codes
+
+If the request is not successful, the client returns an `HTTPError` containing the relevant error code.
+
+|error.status_code|error.message|How to fix|
+|:---|:---|:---|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -1092,7 +1092,7 @@ If the request is not successful, the API returns `json` containing the relevant
 
 This returns the latest version of all templates.
 
-```python
+```
 GET /v2/templates
 ```
 
@@ -1134,7 +1134,7 @@ If the request is successful, the response body is `json` and the status code is
 
 If no templates exist for a template type or there no templates for a service, the client returns a `dict` with an empty `templates` list element:
 
-```python
+```json
 {
     "templates": []
 }
@@ -1166,7 +1166,7 @@ If the request is not successful, the API returns `json` containing the relevant
 
 This generates a preview version of a template.
 
-```python
+```
 POST /v2/templates/{template_id}/preview
 ```
 
@@ -1221,73 +1221,42 @@ If the request is not successful, the API returns `json` containing the relevant
 
 ## Get received text messages
 
+#### Method
+
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.
 
 You can only get the status of messages that are 7 days old or newer.
 
-### Get all received text messages
-
-This method returns a `<generator object>` with all received text messages.
-
-#### Method
-
-```python
-response = get_received_texts_iterator()
+```
+GET /v2/received-text-messages
 ```
 
-#### Response
-
-If the request to the client is successful, the client will return a `<generator object>` that will return all received text messages.
-
-```python
-<generator object NotificationsAPIClient.get_received_texts_iterator at 0x1026c7410>
-```
-
-### Get one page of received text messages
-
-This will return one page of up to 250 text messages.
-
-#### Method
-
-```python
-response = client.get_received_texts(older_than)
-```
-
-You can specify which text messages to receive by inputting the ID of a received text message into the [`older_than`](#get-one-page-of-received-text-messages-arguments-older-than-optional) argument.
-
-#### Arguments
+#### Query parameters
 
 ##### older_than (optional)
 
-Input the ID of a received text message into this argument. If you use this argument, the method returns the next 250 received text messages older than the given ID.
-
-```python
-older_than='740e5834-3a29-46b4-9a6f-16142fde533a' # optional string - notification ID
-```
-
-If you leave out this argument, the method returns the most recent 250 text messages.
+The ID of a received text message. If this is passed, the response will only list text messages received before that message.
 
 #### Response
 
-If the request to the client is successful, the client returns a `dict`.
+If the request is successful, the response body is `json` and the status code is `200`.
 
-```python
+```json
 {
-  "received_text_messages":
-  [
+  "received_text_messages": [
     {
-      "id": "STRING", # required string - ID of received text message
-      "user_number": "STRING", # required string
-      "notify_number": "STRING", # required string - receiving number
+      "id": "740e5834-3a29-46b4-9a6f-16142fde533a", # required string - notification ID
       "created_at": "STRING", # required string - date and time template created
       "service_id": "STRING", # required string - service ID
+      "notify_number": "STRING", # required string - receiving number
+      "user_number": "STRING", # required string
       "content": "STRING" # required string - text content
     },
-    …
+    ...
   ],
   "links": {
-    "current": "/received-text-messages",
-    "next": "/received-text-messages?other_than=last_id_in_list"
+    "current": "STRING", # required string - the requested URL
+    "next": "STRING" # optional string - the URL to request for the next batch of messages
   }
 }
 ```

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -980,10 +980,8 @@ If the request is not successful, the client will return an `HTTPError` containi
 
 This returns the latest version of the template.
 
-```python
-response = notifications_client.get_template(
-  'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
-)
+```
+GET /v2/template/{template_id}
 ```
 
 #### Arguments
@@ -994,11 +992,13 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 
 #### Response
 
-If the request to the client is successful, the client returns a `dict`.
+If the request is successful, the response body is `json` and the status code is `200`.
 
-```python
+##### All messages
+
+```json
 {
-    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+    "id": "f33517ff-2a88-4f6e-b855-c550268ce08a", # required string - template ID
     "name": "STRING", # required string - template name
     "type": "sms / email / letter" , # required string
     "created_at": "STRING", # required string - date and time template created
@@ -1026,11 +1026,8 @@ If the request is not successful, the client returns an `HTTPError` containing t
 
 #### Method
 
-```python
-response = notifications_client.get_template_version(
-    'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
-    'version': INTEGER,
-)
+```
+GET /v2/template/{template_id}/version/{version}
 ```
 
 #### Arguments
@@ -1045,11 +1042,11 @@ The version number of the template.
 
 #### Response
 
-If the request to the client is successful, the client returns a `dict`.
+If the request is successful, the response body is `json` and the status code is `200`.
 
-```python
+```json
 {
-    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+    "id": "f33517ff-2a88-4f6e-b855-c550268ce08a", # required string - template ID
     "name": "STRING", # required string - template name
     "type": "sms / email / letter" , # required string
     "created_at": "STRING", # required string - date and time template created
@@ -1080,12 +1077,10 @@ If the request is not successful, the client returns an `HTTPError` containing t
 This returns the latest version of all templates.
 
 ```python
-response = notifications_client.get_all_templates(
-    template_type="sms / letter / email" # optional string
-)
+GET /v2/templates
 ```
 
-#### Arguments
+#### Query parameters
 
 ##### template_type (optional)
 
@@ -1097,13 +1092,13 @@ If you leave out this argument, the method returns all templates. Otherwise you 
 
 #### Response
 
-If the request to the client is successful, the client returns a `dict`.
+If the request is successful, the response body is `json` and the status code is `200`.
 
-```python
+```json
 {
     "templates": [
         {
-            "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+            "id": "f33517ff-2a88-4f6e-b855-c550268ce08a", # required string - template ID
             "name": "STRING", # required string - template name
             "type": "sms / email / letter" , # required string
             "created_at": "STRING", # required string - date and time template created
@@ -1136,14 +1131,7 @@ If no templates exist for a template type or there no templates for a service, t
 This generates a preview version of a template.
 
 ```python
-response = notifications_client.post_template_preview(
-    template_id='f33517ff-2a88-4f6e-b855-c550268ce08a', # required UUID string
-    personalisation={
-        'KEY': 'VALUE',
-        'KEY': 'VALUE',
-        ...
-        }, # required dict - specifies template parameters
-)
+POST /v2/templates/{template_id}/preview
 ```
 
 The parameters in the personalisation argument must match the placeholder fields in the actual template. The API notification client will ignore any extra fields in the method.
@@ -1154,22 +1142,26 @@ The parameters in the personalisation argument must match the placeholder fields
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
 
-##### personalisation (required)
+#### Request body
+
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a dictionary with key value pairs. For example:
 
-```python
-personalisation={
-    'first_name': 'Amala',
-    'application_date': '2018-01-01',
+```json
+{
+  "personalisation": {
+    "first_name": "Amala",
+    "application_date": "2018-01-01",
+  }
 }
 ```
 
 #### Response
 
-If the request to the client is successful, you receive a `dict` response.
+If the request is successful, the response body is `json` and the status code is `200`.
 
-```python
+```json
 {
     "id": "740e5834-3a29-46b4-9a6f-16142fde533a", # required string - notification ID
     "type": "sms / email / letter" , # required string

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -959,8 +959,6 @@ If the request is not successful, the API returns `json` containing the relevant
 }
 ```
 
-If the request is not successful, the client will return an `HTTPError` containing the relevant error code:
-
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
@@ -1013,13 +1011,22 @@ If the request is successful, the response body is `json` and the status code is
 
 #### Error codes
 
-If the request is not successful, the client returns an `HTTPError` containing the relevant error code:
+If the request is not successful, the API returns `json` containing the relevant error code. For example:
+
+```json
+{
+  "status_code": 404,
+  "errors": [
+    {"error": "NoResultFound", "message": "No result found"}
+  ]
+}
+```
 
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
-|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-arguments-template-id-required)|
+|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-arguments-template-id-required)|
 
 
 ### Get a template by ID and version
@@ -1061,13 +1068,22 @@ If the request is successful, the response body is `json` and the status code is
 
 #### Error codes
 
-If the request is not successful, the client returns an `HTTPError` containing the relevant error code:
+If the request is not successful, the API returns `json` containing the relevant error code. For example:
+
+```json
+{
+  "status_code": 404,
+  "errors": [
+    {"error": "NoResultFound", "message": "No result found"}
+  ]
+}
+```
 
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
-|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-and-version-arguments-template-id-required) and [version](#version-required)|
+|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-and-version-arguments-template-id-required) and [version](#version-required)|
 
 
 ### Get all templates
@@ -1082,7 +1098,7 @@ GET /v2/templates
 
 #### Query parameters
 
-##### template_type (optional)
+##### type (optional)
 
 If you leave out this argument, the method returns all templates. Otherwise you can filter by:
 
@@ -1123,6 +1139,26 @@ If no templates exist for a template type or there no templates for a service, t
     "templates": []
 }
 ```
+
+#### Error codes
+
+If the request is not successful, the API returns `json` containing the relevant error code. For example:
+
+```json
+{
+  "status_code": 400,
+  "errors": [
+    {"error": "ValidationError", "message": "type blah is not one of [sms, email, letter, broadcast]"}
+  ]
+}
+```
+
+|error.status_code|error.message|Notes|
+|:---|:---|:---|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "type <TYPE> is not one of [sms, email, letter, broadcast]"`<br>`}]`|Make sure that the provided `type` is one of: email, sms, letter |
+|`400`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the [template ID](#generate-a-preview-template-arguments-template-id-required)|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
 ### Generate a preview template
 
@@ -1173,7 +1209,7 @@ If the request is successful, the response body is `json` and the status code is
 
 #### Error codes
 
-If the request is not successful, the client returns an `HTTPError` containing the relevant error code:
+If the request is not successful, the API returns `json` containing the relevant error code. For example:
 
 |error.status_code|error.message|Notes|
 |:---|:---|:---|

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -1221,6 +1221,13 @@ If the request is not successful, the API returns `json` containing the relevant
 
 ## Get received text messages
 
+### Enable received text messages
+
+To receive text messages:
+
+1. Go to the **Text message settings** section of the **Settings** page.
+1. Select **Change** on the **Receive text messages** row.
+
 #### Method
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.


### PR DESCRIPTION
The following sections were missing from the REST API documentation:

- Get a template
  - Get a template by ID
  - Get a template by ID and version
  - Get all templates
  - Generate a preview template
- Get received text messages
  - Get all received text messages
  - Get one page of received text messages

I spotted this when trying to add the latest ‘receive text message’ guidance.