### PR TITLE
Fix quote style to make docs display consistently

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -840,7 +840,7 @@ If the request is successful, the response body is `json` and the status code is
       "status": "sending / delivered / permanent-failure / temporary-failure / technical-failure", # required string
       "template": {
         "version": 1
-        "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
+        "id": "f33517ff-2a88-4f6e-b855-c550268ce08a" # required string - template ID
         "uri": "/v2/template/{id}/{version}", # required
       },
       "body": "STRING", # required string - body of notification


### PR DESCRIPTION
Before
<img width="720" alt="Screenshot 2023-09-25 at 09 52 41" src="https://github.com/alphagov/notifications-tech-docs/assets/12881990/6d1901de-efbd-4ba7-b193-c9dbaa171746">

After
<img width="658" alt="Screenshot 2023-09-25 at 09 52 45" src="https://github.com/alphagov/notifications-tech-docs/assets/12881990/1f699447-6798-4387-ab91-b8faa05e8660">
