### PR TITLE
Fix argument in "Send a precompiled letter" section

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -617,7 +617,7 @@ POST /v2/notifications/letter
 
 An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
-##### pdf_file (required)
+##### content (required)
 
 The precompiled letter must be a PDF file which meets [the GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification). You’ll need to convert the file into a string that is base64 encoded.
 


### PR DESCRIPTION
The code examples were correct for this endpoint were correct, but the headings gave one of the arguments as "pdf_file" instead of "content".