### PR TITLE
Run 2 instances always

### DIFF
--- a/manifest.yml.tpl
+++ b/manifest.yml.tpl
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: notify-tech-docs
+  instances: 2
   memory: 64M
   buildpack: staticfile_buildpack
   health-check-type: http


### PR DESCRIPTION
At the moment we aren't specifying, so are only running 1. This is nearly always fine but means if our single instance crashes then we will be serving errors to users.

We have 2 for resiliency.