### PR TITLE
Remove old copy about manual contact for inbound sms

### DIFF
--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -49,8 +49,6 @@ The callback message is formatted in JSON. All of the values are strings, apart 
 
 If your service receives text messages in Notify, Notify can forward them to your callback URL as soon as they arrive.
 
-Contact the Notify team using the [support page](https://www.notifications.service.gov.uk/support) or [chat to us on Slack](https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC) to request a unique number for text message replies.
-
 The callback message is formatted in JSON. All of the values are strings. The key, description and format of the callback message arguments will be:
 
 |Key | Description | Format|


### PR DESCRIPTION
We may instead want to replace this with similar content to https://github.com/alphagov/notifications-python-client/pull/229/files but given the headings would be slightly different and so this isn't just a copy and paste job, I went for the quicker option.

Happy for someone to put some commits on top to change the content if they want to, but at least this removes the incorrect information I guess?