### PR TITLE
One click unsubscribe url

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -242,6 +242,24 @@ An identifier you can create if necessary. This reference identifies a single no
 ```
 You can leave out this argument if you do not have a reference.
 
+##### one_click_unsubscribe_url (optional)
+
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+This is an optional argument that is only required for subscription emails.
+
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+
+```json
+"one_click_unsubscribe_url": "https://example.com/unsubscribe.html?opaque=123456789"
+```
+
+The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+
+Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
+You can leave out this argument if the email being sent is not a subscription email.
+
 ##### email_reply_to_id (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -254,7 +254,7 @@ Read our Using Notify page for more information about [unsubscribe links](https:
 "one_click_unsubscribe_url": "https://example.com/unsubscribe.html?opaque=123456789"
 ```
 
-The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -246,8 +246,6 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-This is an optional argument that is only required for subscription emails.
-
 Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```json

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -224,7 +224,7 @@ Read our Using Notify page for more information about [unsubscribe links](https:
 URI oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'
 ```
 
-The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -212,6 +212,23 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference='STRING';
 ```
 
+##### oneClickUnsubscribeURL (optional)
+
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+This is an optional argument that is only required for subscription emails.
+
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+
+```java
+URI oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'
+```
+
+The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+
+Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
+
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
@@ -237,6 +254,7 @@ If the request to the client is successful, the client returns a `SendEmailRespo
 ```java
 UUID notificationId;
 Optional<String> reference;
+Optional<URI> oneClickUnsubscribeURL;
 UUID templateId;
 int templateVersion;
 String templateUri;

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -216,8 +216,6 @@ String reference='STRING';
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-This is an optional argument that is only required for subscription emails.
-
 Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```java

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -228,7 +228,6 @@ The one-click unsubscribe URL must respond to an empty POST request by unsubscri
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
-
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -228,6 +228,8 @@ The one-click unsubscribe URL must respond to an empty POST request by unsubscri
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
+You can leave out this argument if the email being sent is not a subscription email.
+
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -272,8 +272,6 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-This is an optional argument that is only required for subscription emails.
-
 Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```csharp

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -284,6 +284,8 @@ The one-click unsubscribe URL must respond to an empty POST request by unsubscri
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
+You can leave out this argument if the email being sent is not a subscription email.
+
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -268,6 +268,22 @@ string reference: "STRING";
 ```
 You can leave out this argument if you do not have a reference.
 
+##### oneClickUnsubscribeURL (optional)
+
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+This is an optional argument that is only required for subscription emails.
+
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+
+```csharp
+string oneClickUnsubscribeURL : 'https://example.com/unsubscribe.html?opaque=123456789';
+```
+
+The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+
+Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
@@ -295,6 +311,7 @@ If the request to the client is successful, the client returns an `EmailNotifica
 ```csharp
 public String id;
 public String reference;
+public String oneClickUnsubscribeURL;
 public String uri;
 public Template template;
 public EmailResponseContent content;

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -280,7 +280,7 @@ Read our Using Notify page for more information about [unsubscribe links](https:
 string oneClickUnsubscribeURL : 'https://example.com/unsubscribe.html?opaque=123456789';
 ```
 
-The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -238,8 +238,6 @@ A unique identifier you create. This reference identifies a single unique notifi
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-This is an optional argument that is only required for subscription emails.
-
 Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```javascript

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -246,7 +246,7 @@ Read our Using Notify page for more information about [unsubscribe links](https:
 oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'
 ```
 
-The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -175,6 +175,7 @@ notifyClient
   .sendEmail(templateId, emailAddress, {
     personalisation: personalisation,
     reference: reference,
+    oneClickUnsubscribeURL: oneClickUnsubscribeURL,  
     emailReplyToId: emailReplyToId
   })
   .then(response => console.log(response))
@@ -233,6 +234,22 @@ A unique identifier you create. This reference identifies a single unique notifi
 "your_reference_here"
 ```
 
+##### oneClickUnsubscribeURL (optional)
+
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+This is an optional argument that is only required for subscription emails.
+
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+
+```javascript
+oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'
+```
+
+The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+
+Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
@@ -259,6 +276,7 @@ If the request is successful, the promise resolves with a `response` `object`. F
 {
   'id': 'bfb50d92-100d-4b8b-b559-14fa3b091cda',
   'reference': null,
+  'oneClickUnsubscribeURL': null,      
   'content': {
     'subject': 'Licence renewal',
     'body': 'Dear Bill, your licence is due for renewal on 3 January 2016.',

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -250,6 +250,8 @@ The one-click unsubscribe URL must respond to an empty POST request by unsubscri
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
+You can leave out this argument if the email being sent is not a subscription email.
+
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -231,8 +231,6 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
-You can leave out this argument if the email being sent is not a subscription email.
-
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -221,8 +221,6 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-This is an optional argument that is only required for subscription emails.
-
 Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```php

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -172,7 +172,6 @@ try {
         ],
         'unique_ref123',
         '862bfaaf-9f89-43dd-aafa-2868ce2926a9',
-        'https://example.com/unsubscribe.html?opaque=123456789'
         );
 
 } catch (ApiException $e){}

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -157,7 +157,7 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 #### Method
 
 ```php
-sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL )
+sendEmail( $emailAddress, $templateId, array $personalisation = array(), $reference = '', $emailReplyToId = NULL, $oneClickUnsubscribeURL = NULL )
 ```
 For example:
 
@@ -171,7 +171,8 @@ try {
             'dob'  => '12 July 1968'
         ],
         'unique_ref123',
-        '862bfaaf-9f89-43dd-aafa-2868ce2926a9'
+        '862bfaaf-9f89-43dd-aafa-2868ce2926a9',
+        'https://example.com/unsubscribe.html?opaque=123456789'
         );
 
 } catch (ApiException $e){}
@@ -214,8 +215,25 @@ A unique identifier you can create if necessary. This reference identifies a sin
 ```php
 $reference = 'STRING';
 ```
-
 You can leave out this argument if you do not have a reference.
+
+##### one_click_unsubscribe_url (optional)
+
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+This is an optional argument that is only required for subscription emails.
+
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+
+```php
+$one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456789'
+```
+
+The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+
+Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
+You can leave out this argument if the email being sent is not a subscription email.
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -229,7 +229,7 @@ Read our Using Notify page for more information about [unsubscribe links](https:
 $one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456789'
 ```
 
-The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -195,6 +195,24 @@ reference='STRING', # optional string - identifies notification(s)
 
 You can leave out this argument if you do not have a reference.
 
+##### one_click_unsubscribe_url (optional)
+
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+This is an optional argument that is only required for subscription emails.
+
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+
+```python
+one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456789'
+```
+
+The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+
+Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
+You can leave out this argument if the email being sent is not a subscription email.
+
 ##### email_reply_to_id (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -199,8 +199,6 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-This is an optional argument that is only required for subscription emails.
-
 Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```python

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -207,7 +207,7 @@ Read our Using Notify page for more information about [unsubscribe links](https:
 one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456789'
 ```
 
-The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -203,6 +203,24 @@ reference: "your_reference_string"
 
 You can leave out this argument if you do not have a reference.
 
+##### one_click_unsubscribe_url (optional)
+
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+This is an optional argument that is only required for subscription emails.
+
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+
+```ruby
+one_click_unsubscribe_url: "https://example.com/unsubscribe.html?opaque=123456789"
+```
+
+The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+
+Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
+You can leave out this argument if the email being sent is not a subscription email.
+
 ##### email_reply_to_id (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -215,7 +215,7 @@ Read our Using Notify page for more information about [unsubscribe links](https:
 one_click_unsubscribe_url: "https://example.com/unsubscribe.html?opaque=123456789"
 ```
 
-The one-click unsubscribe URL must respond to an empty POST request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
+The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -207,8 +207,6 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-This is an optional argument that is only required for subscription emails.
-
 Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```ruby


### PR DESCRIPTION
This PR updates all our API client documents and the generic API document to detail the addition of the `one_click_unsubscribe_url` parameter.