### PR TITLE
Remove redundant header from send letter section of PHP docs

### DIFF
--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -457,8 +457,6 @@ If the request is not successful, the client returns an `Alphagov\Notifications\
 
 ### Send a letter
 
-#### Prerequisites
-
 When you add a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). You can only send letters when your service is live.
 
 To send Notify a request to go live:


### PR DESCRIPTION
None of the other clients have this header at the start of their ‘Send a letter‘ sections

Compare before:

PHP | Python
---|---
<img width="834" alt="image" src="https://github.com/alphagov/notifications-tech-docs/assets/355079/031151e0-65ee-4e83-ae69-be5bfcff5096"> | <img width="826" alt="image" src="https://github.com/alphagov/notifications-tech-docs/assets/355079/c49d70cf-cbae-47aa-bff1-738b70037267">

