### PR TITLE
Make proposition line consistent across docs

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -68,7 +68,7 @@ The content header is `application/json`:
 
 ## Send a message
 
-You can use GOV.UK Notify to send text messages, emails and letters.
+You can use GOV.UK Notify to send emails, text messages and letters.
 
 ### Send a text message
 
@@ -246,7 +246,7 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```json
 "one_click_unsubscribe_url": "https://example.com/unsubscribe.html?opaque=123456789"

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -35,7 +35,7 @@ NotificationClient client = new NotificationClient(apiKey, proxy);
 
 ## Send a message
 
-You can use GOV.UK Notify to send text messages, emails and letters.
+You can use GOV.UK Notify to send emails, text messages and letters.
 
 ### Send a text message
 
@@ -216,7 +216,7 @@ String reference='STRING';
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```java
 URI oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -79,7 +79,7 @@ var client = new NotificationClient(httpClientWithProxy, apiKey);
 
 ## Send a message
 
-You can use GOV.UK Notify to send text messages, emails and letters.
+You can use GOV.UK Notify to send emails, text messages and letters.
 
 ### Send a text message
 
@@ -272,7 +272,7 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```csharp
 string oneClickUnsubscribeURL : 'https://example.com/unsubscribe.html?opaque=123456789';

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -53,7 +53,7 @@ where `customAxiosClient` is an instance of Axios.
 
 ## Send a message
 
-You can use GOV.UK Notify to send text messages, emails (including documents) and letters.
+You can use GOV.UK Notify to send emails, text messages and letters.
 
 ### Send a text message
 
@@ -187,7 +187,7 @@ notifyClient
   .sendEmail(templateId, emailAddress, {
     personalisation: personalisation,
     reference: reference,
-    oneClickUnsubscribeURL: oneClickUnsubscribeURL,  
+    oneClickUnsubscribeURL: oneClickUnsubscribeURL,
     emailReplyToId: emailReplyToId
   })
   .then(response => console.log(response))
@@ -250,7 +250,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```javascript
 oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'
@@ -288,7 +288,7 @@ If the request is successful, the promise resolves with a `response` `object`. F
 {
   'id': 'bfb50d92-100d-4b8b-b559-14fa3b091cda',
   'reference': null,
-  'oneClickUnsubscribeURL': null,      
+  'oneClickUnsubscribeURL': null,
   'content': {
     'subject': 'Licence renewal',
     'body': 'Dear Bill, your licence is due for renewal on 3 January 2016.',

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -37,7 +37,7 @@ The default timeout is 30 seconds. For more information about timeouts see https
 
 ## Send a message
 
-You can use GOV.UK Notify to send text messages, emails and letters.
+You can use GOV.UK Notify to send emails, text messages and letters.
 
 ### Send a text message
 
@@ -199,7 +199,7 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```python
 one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456789'

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -27,7 +27,7 @@ To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.
 
 ## Send a message
 
-You can use GOV.UK Notify to send text messages, emails or letters.
+You can use GOV.UK Notify to send emails, text messages and letters.
 
 ### Send a text message
 
@@ -207,7 +207,7 @@ You can leave out this argument if you do not have a reference.
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
 
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
+Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```ruby
 one_click_unsubscribe_url: "https://example.com/unsubscribe.html?opaque=123456789"


### PR DESCRIPTION
We always say emails, text messages and letters, in that order.

We don’t talk about ‘documents’ as part of the high-level product proposition.