### PR TITLE
chore(client-docs): update remaining client docs

### DIFF
--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -686,30 +686,51 @@ The ID of the notification. To find the notification ID, you can either:
 If the request to the client is successful, the client returns a `Notification`:
 
 ```java
-UUID id;
-Optional<String> reference;
-Optional<String> emailAddress;
-Optional<String> phoneNumber;
-Optional<String> line1;
-Optional<String> line2;
-Optional<String> line3;
-Optional<String> line4;
-Optional<String> line5;
-Optional<String> line6;
-Optional<String> line7;
-Optional<String> postage;
-String notificationType;
-String status;
-UUID templateId;
-int templateVersion;
-String templateUri;
-String body;
-Optional<String subject;
-ZonedDateTime createdAt;
-Optional<ZonedDateTime> sentAt;
-Optional<ZonedDateTime> completedAt;
-Optional<ZonedDateTime> estimatedDelivery;
-Optional<String> createdByName;
+public class Notification {
+    private UUID id;  // required string - notification ID
+    private Optional<String> reference;  // optional string - client reference
+    private Optional<String> emailAddress;  // required string for emails
+    private Optional<String> phoneNumber;  // required string for text messages
+    private Optional<String> line1;  // required string for letter
+    private Optional<String> line2;  // required string for letter
+    private Optional<String> line3;  // required string for letter
+    private Optional<String> line4;  // optional string for letter
+    private Optional<String> line5;  // optional string for letter
+    private Optional<String> line6;  // optional string for letter
+    private Optional<String> line7;  // optional string for letter
+    private Optional<String> postage;  // required string for letter
+    private String notificationType;  // required string
+    private String status;  // required string
+    private Template template;  // template details
+    private String body;  // required string - body of notification
+    private Optional<String> subject;  // required string for email - subject of email
+    private ZonedDateTime createdAt;  // required string - date and time notification created
+    private Optional<ZonedDateTime> sentAt;  // optional string - date and time notification sent to provider
+    private Optional<ZonedDateTime> completedAt;  // optional string - date and time notification delivered or failed
+    private Optional<ZonedDateTime> scheduledFor;  // optional string - date and time notification has been scheduled to be sent at
+    private Optional<String> oneClickUnsubscribe;  // optional string, email only - URL that you provided so your recipients can unsubscribe
+    private boolean isCostDataReady;  // required boolean, this field is true if cost data is ready, and false if it isn't
+    private double costInPounds;  // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+    private CostDetails costDetails;  // cost details for messages
+    private Optional<String> createdByName;  // optional string - name of the person who sent the notification if sent manually
+}
+
+class Template {
+    private UUID id;  // required string - template ID
+    private String uri;  // required string
+    private int version;  // required integer
+}
+
+class CostDetails {
+// required for sms only
+    private Optional<Integer> billableSmsFragments;  // optional integer - number of billable SMS fragments in your text message
+    private Optional<Integer> internationalRateMultiplier;  // optional integer - for international SMS rate is multiplied by this value
+    private Optional<Double> smsRate;  // optional number - cost of 1 SMS fragment
+    
+// required for letters only
+    private Optional<Integer> billableSheetsOfPaper;  // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+    private Optional<String> postage;  // optional string
+}
 ```
 
 #### Error codes

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -718,27 +718,35 @@ The ID of the notification. To find the notification ID, you can either:
 If the request to the client is successful, the client returns a `Notification`.
 
 ```csharp
-public String id;
-public String completedAt;
-public String createdAt;
-public String emailAddress;
-public String body;
-public String subject;
-public String line1;
-public String line2;
-public String line3;
-public String line4;
-public String line5;
-public String line6;
-public String line7;
-public String phoneNumber;
-public String postage;
-public String reference;
-public String sentAt;
-public String status;
-public Template template;
-public String type;
-public string createdByName;
+public class Notification
+{
+    public string id;  // required string - notification ID
+    public string reference;  // optional string - client reference
+    public string emailAddress;  // required string for emails
+    public string phoneNumber;  // required string for text messages
+    public string line1;  // required string for letter
+    public string line2;  // required string for letter
+    public string line3;  // required string for letter
+    public string line4;  // optional string for letter
+    public string line5;  // optional string for letter
+    public string line6;  // optional string for letter
+    public string line7;  // optional string for letter
+    public string postage;  // required string for letter
+    public string type;  // required string
+    public string status;  // required string
+    public Template template;  // template details
+    public string body;  // required string - body of notification
+    public string subject;  // required string for email - subject of email
+    public string createdAt;  // required string - date and time notification created
+    public string createdByName;  // optional string - name of the person who sent the notification if sent manually
+    public string sentAt;  // optional string - date and time notification sent to provider
+    public string completedAt;  // optional string - date and time notification delivered or failed
+    public string scheduledFor;  // optional string - date and time notification has been scheduled to be sent at
+    public string oneClickUnsubscribe;  // optional string, email only - URL that you provided so your recipients can unsubscribe
+    public bool isCostDataReady;  // required boolean, this field is true if cost data is ready, and false if it isn't
+    public double costInPounds;  // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+    public CostDetails costDetails;  // cost details for messages
+}
 
 public class Template
 {
@@ -747,6 +755,16 @@ public class Template
     public Int32 version;
 }
 
+public class CostDetails
+{
+    // for text messages:
+    public int billableSmsFragments;  // optional integer - number of billable SMS fragments in your text message
+    public int internationalRateMultiplier;  // optional integer - for international SMS rate is multiplied by this value
+    public double smsRate;  // optional number - cost of 1 SMS fragment
+    // for letters:
+    public int billableSheetsOfPaper;  // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+    public string postage;  // optional string
+}
 
 ```
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -749,30 +749,44 @@ If the request is successful, the promise resolves with a `response` `object`. F
 
 ```javascript
 {
-  'id': 'notify_id',
-  'body': 'Hello Foo',
-  'subject': 'null|email_subject',
-  'reference': 'client reference',
-  'email_address': 'email address',
-  'phone_number': 'phone number',
-  'line_1': 'full name of a person or company',
-  'line_2': '123 The Street',
-  'line_3': 'Some Area',
-  'line_4': 'Some Town',
-  'line_5': 'Some county',
-  'line_6': 'Something else',
-  'line_7': 'UK postcode or country',
-  'postage': 'first or second',
-  'type': 'sms|letter|email',
-  'status': 'current status',
-  'template': {
-    'version': 1,
-    'id': 1,
-    'uri': '/template/{id}/{version}'
+  "id": "740e5834-3a29-46b4-9a6f-16142fde533a", // required string - notification ID
+  "reference": "STRING", // optional string - client reference
+  "email_address": "sender@something.com", // required string for emails
+  "phone_number": "+447900900123", // required string for text messages
+  "line_1": "ADDRESS LINE 1", // required string for letter
+  "line_2": "ADDRESS LINE 2", // required string for letter
+  "line_3": "ADDRESS LINE 3", // required string for letter
+  "line_4": "ADDRESS LINE 4", // optional string for letter
+  "line_5": "ADDRESS LINE 5", // optional string for letter
+  "line_6": "ADDRESS LINE 6", // optional string for letter
+  "line_7": "ADDRESS LINE 7", // optional string for letter
+  "postage": "first / second / europe / rest-of-world", // required string for letter
+  "type": "sms / letter / email", // required string
+  "status": "sending / delivered / permanent-failure / temporary-failure / technical-failure", // required string
+  "template": {
+    "version": 1, // required integer
+    "id": "f33517ff-2a88-4f6e-b855-c550268ce08a", // required string - template ID
+    "uri": "/v2/template/{id}/{version}" // required string
   },
-  'created_by_name': 'name of the person who sent the notification if sent manually',
-  'created_at': 'created at',
-  'sent_at': 'sent to provider at'
+  "body": "STRING", // required string - body of notification
+  "subject": "STRING", // required string for email - subject of email
+  "created_at": "2024-05-17 15:58:38.342838", // required string - date and time notification created
+  "created_by_name": "STRING", // optional string - name of the person who sent the notification if sent manually
+  "sent_at": "2024-05-17 15:58:30.143000", // optional string - date and time notification sent to provider
+  "completed_at": "2024-05-17 15:59:10.321000", // optional string - date and time notification delivered or failed
+  "scheduled_for": "2024-05-17 9:00:00.000000", // optional string - date and time notification has been scheduled to be sent at
+  "one_click_unsubscribe": "STRING", // optional string, email only - URL that you provided so your recipients can unsubscribe
+  "is_cost_data_ready": true, // required boolean, this field is true if cost data is ready, and false if it isn't
+  "cost_in_pounds": 0.0027, // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+  "cost_details": {
+    // for text messages:
+    "billable_sms_fragments": 1, // optional integer - number of billable sms fragments in your text message
+    "international_rate_multiplier": 1, // optional integer - for international sms rate is multiplied by this value
+    "sms_rate": 0.0027, // optional number - cost of 1 sms fragment
+    // for letters:
+    "billable_sheets_of_paper": 2, // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+    "postage": "first / second / europe / rest-of-world" // optional string
+  }
 }
 ```
 
@@ -859,36 +873,51 @@ If the request is successful, the promise resolves with a `response` `object`. F
 
 ```javascript
 {
-  'notifications': [
+  "notifications": [
     {
-      'id': 'notify_id',
-      'reference': 'client reference',
-      'email_address': 'email address',
-      'phone_number': 'phone number',
-      'line_1': 'full name of a person or company',
-      'line_2': '123 The Street',
-      'line_3': 'Some Area',
-      'line_4': 'Some Town',
-      'line_5': 'Some county',
-      'line_6': 'Something else',
-      'postcode': 'postcode',
-      'postage': 'first or second',
-      'type': 'sms | letter | email',
-      'status': 'sending | delivered | permanent-failure | temporary-failure | technical-failure',
-      'template': {
-        'version': 1,
-        'id': 1,
-        'uri': '/template/{id}/{version}'
+      "id": "740e5834-3a29-46b4-9a6f-16142fde533a",  // required string - notification ID
+      "reference": "STRING",  // optional string - client reference
+      "email_address": "sender@something.com",  // required string for emails
+      "phone_number": "+447900900123",  // required string for text messages
+      "line_1": "ADDRESS LINE 1",  // required string for letter
+      "line_2": "ADDRESS LINE 2",  // required string for letter
+      "line_3": "ADDRESS LINE 3",  // required string for letter
+      "line_4": "ADDRESS LINE 4",  // optional string for letter
+      "line_5": "ADDRESS LINE 5",  // optional string for letter
+      "line_6": "ADDRESS LINE 6",  // optional string for letter
+      "line_7": "ADDRESS LINE 7", // optional string for letter
+      "postage": "first / second / europe / rest-of-world", // required string for letter
+      "type": "sms / letter / email",  // required string
+      "status": "sending / delivered / permanent-failure / temporary-failure / technical-failure",  // required string
+      "template": {
+        "version": 1, // required integer
+        "id": "f33517ff-2a88-4f6e-b855-c550268ce08a",  // required string - template ID
+        "uri": "/v2/template/{id}/{version}"  // required string
       },
-      'created_by_name': 'name of the person who sent the notification if sent manually',
-      'created_at': 'created at',
-      'sent_at': 'sent to provider at'
+      "body": "STRING",  // required string - body of notification
+      "subject": "STRING",  // required string for email - subject of email
+      "created_at": "2024-05-17 15:58:38.342838",  // required string - date and time notification created
+      "created_by_name": "STRING",  // optional string - name of the person who sent the notification if sent manually
+      "sent_at": "2024-05-17 15:58:30.143000",  // optional string - date and time notification sent to provider
+      "completed_at": "2024-05-17 15:59:10.321000",  // optional string - date and time notification delivered or failed
+      "scheduled_for": "2024-05-17 9:00:00.000000", // optional string - date and time notification has been scheduled to be sent at
+      "one_click_unsubscribe": "STRING", // optional string, email only - URL that you provided so your recipients can unsubscribe
+      "is_cost_data_ready": true,  // required boolean, this field is true if cost data is ready, and false if it isn't
+      "cost_in_pounds": 0.0027,  // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+      "cost_details": {
+        // for text messages:
+    "billable_sms_fragments": 1,  // optional integer - number of billable sms fragments in your text message
+      "international_rate_multiplier": 1,  // optional integer - for international sms rate is multiplied by this value
+      "sms_rate": 0.0027,  // optional number - cost of 1 sms fragment
+      // for letters:
+    "billable_sheets_of_paper": 2,  // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+      "postage": "first / second / europe / rest-of-world"  // optional string
     }
-    // …
+  }
   ],
-  'links': {
-    'current': '/notifications?template_type=sms&status=delivered',
-    'next': '/notifications?other_than=last_id_in_list&template_type=sms&status=delivered'
+  "links": {
+    "current": "/notifications?template_type=sms&status=delivered",
+    "next": "/notifications?other_than=last_id_in_list&template_type=sms&status=delivered"
   }
 }
 ```

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -698,29 +698,44 @@ If the request to the client is successful, the client returns an `array`:
 
 ```php
 [
-    "id" => "notify_id",
-    "body" => "Hello Foo",
-    "subject" => "null|email_subject",
-    "reference" => "client reference",
-    "email_address" => "email address",
-    "phone_number" => "phone number",
-    "line_1" => "full name of a person or company",
-    "line_2" => "123 The Street",
-    "line_3" => "Some Area",
-    "line_4" => "Some Town",
-    "line_5" => "Some county",
-    "line_6" => "Something else",
-    "line_7" => "Postcode or country",
-    "postage" => "null|first|second",
-    "type" => "sms|letter|email",
-    "status" => "current status",
+    "id" => "740e5834-3a29-46b4-9a6f-16142fde533a", // required string - notification ID
+    "reference" => "STRING", // optional string - client reference
+    "email_address" => "sender@something.com", // required string for emails
+    "phone_number" => "+447900900123", // required string for text messages
+    "line_1" => "ADDRESS LINE 1", // required string for letter
+    "line_2" => "ADDRESS LINE 2", // required string for letter
+    "line_3" => "ADDRESS LINE 3", // required string for letter
+    "line_4" => "ADDRESS LINE 4", // optional string for letter
+    "line_5" => "ADDRESS LINE 5", // optional string for letter
+    "line_6" => "ADDRESS LINE 6", // optional string for letter
+    "line_7" => "ADDRESS LINE 7", // optional string for letter
+    "postage" => "first / second / europe / rest-of-world", // required string for letter
+    "type" => "sms / letter / email", // required string
+    "status" => "sending / delivered / permanent-failure / temporary-failure / technical-failure", // required string
     "template" => [
-        "version" => 1,
-        "id" => 1,
-        "uri" => "/template/{id}/{version}"
-     ],
-    "created_at" => "created at",
-    "sent_at" => "sent to provider at",
+        "version" => 1, // required integer
+        "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a", // required string - template ID
+        "uri" => "/v2/template/{id}/{version}" // required string
+    ],
+    "body" => "STRING", // required string - body of notification
+    "subject" => "STRING", // required string for email - subject of email
+    "created_at" => "2024-05-17 15:58:38.342838", // required string - date and time notification created
+    "created_by_name" => "STRING", // optional string - name of the person who sent the notification if sent manually
+    "sent_at" => "2024-05-17 15:58:30.143000", // optional string - date and time notification sent to provider
+    "completed_at" => "2024-05-17 15:59:10.321000", // optional string - date and time notification delivered or failed
+    "scheduled_for" => "2024-05-17 9:00:00.000000", // optional string - date and time notification has been scheduled to be sent at
+    "one_click_unsubscribe" => "STRING", // optional string, email only - URL that you provided so your recipients can unsubscribe
+    "is_cost_data_ready" => true, // required boolean, this field is true if cost data is ready, and false if it isn't
+    "cost_in_pounds" => 0.0027, // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+    "cost_details" => [
+        // for text messages:
+        "billable_sms_fragments" => 1, // optional integer - number of billable sms fragments in your text message
+        "international_rate_multiplier" => 1, // optional integer - for international sms rate is multiplied by this value
+        "sms_rate" => 0.0027, // optional number - cost of 1 sms fragment
+        // for letters:
+        "billable_sheets_of_paper" => 2, // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+        "postage" => "first / second / europe / rest-of-world" // optional string
+    ]
 ];
 ```
 
@@ -815,34 +830,51 @@ If the request to the client is successful, the client returns an `array`.
 ```php
 [
     "notifications" => [
-            "id" => "notify_id",
-            "reference" => "client reference",
-            "email_address" => "email address",
-            "phone_number" => "phone number",
-            "line_1" => "full name of a person or company",
-            "line_2" => "123 The Street",
-            "line_3" => "Some Area",
-            "line_4" => "Some Town",
-            "line_5" => "Some county",
-            "line_6" => "Something else",
-            "postcode" => "postcode",
-            "postage" => "null|first|second",
-            "type" => "sms | letter | email",
-            "status" => sending | delivered | permanent-failure | temporary-failure | technical-failure
+        [
+            "id" => "740e5834-3a29-46b4-9a6f-16142fde533a",  // required string - notification ID
+            "reference" => "STRING",  // optional string - client reference
+            "email_address" => "sender@something.com",  // required string for emails
+            "phone_number" => "+447900900123",  // required string for text messages
+            "line_1" => "ADDRESS LINE 1",  // required string for letter
+            "line_2" => "ADDRESS LINE 2",  // required string for letter
+            "line_3" => "ADDRESS LINE 3",  // required string for letter
+            "line_4" => "ADDRESS LINE 4",  // optional string for letter
+            "line_5" => "ADDRESS LINE 5",  // optional string for letter
+            "line_6" => "ADDRESS LINE 6",  // optional string for letter
+            "line_7" => "ADDRESS LINE 7",  // optional string for letter
+            "postage" => "first / second / europe / rest-of-world",  // required string for letter
+            "type" => "sms / letter / email",  // required string
+            "status" => "sending / delivered / permanent-failure / temporary-failure / technical-failure",  // required string
             "template" => [
-            "version" => 1,
-            "id" => 1,
-            "uri" => "/template/{id}/{version}"
-        ],
-        "created_at" => "created at",
-        "sent_at" => "sent to provider at",
-        ],
-        …
-  ],
-  "links" => [
-     "current" => "/notifications?template_type=sms&status=delivered",
-     "next" => "/notifications?older_than=last_id_in_list&template_type=sms&status=delivered"
-  ]
+                "version" => 1,  // required integer
+                "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",  // required string - template ID
+                "uri" => "/v2/template/{id}/{version}"  // required string
+            ],
+            "body" => "STRING",  // required string - body of notification
+            "subject" => "STRING",  // required string for email - subject of email
+            "created_at" => "2024-05-17 15:58:38.342838",  // required string - date and time notification created
+            "created_by_name" => "STRING",  // optional string - name of the person who sent the notification if sent manually
+            "sent_at" => "2024-05-17 15:58:30.143000",  // optional string - date and time notification sent to provider
+            "completed_at" => "2024-05-17 15:59:10.321000",  // optional string - date and time notification delivered or failed
+            "scheduled_for" => "2024-05-17 9:00:00.000000",  // optional string - date and time notification has been scheduled to be sent at
+            "one_click_unsubscribe" => "STRING",  // optional string, email only - URL that you provided so your recipients can unsubscribe
+            "is_cost_data_ready" => true,  // required boolean, this field is true if cost data is ready, and false if it isn't
+            "cost_in_pounds" => 0.0027,  // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+            "cost_details" => [
+                // for text messages:
+                "billable_sms_fragments" => 1,  // optional integer - number of billable sms fragments in your text message
+                "international_rate_multiplier" => 1,  // optional integer - for international sms rate is multiplied by this value
+                "sms_rate" => 0.0027,  // optional number - cost of 1 sms fragment
+                // for letters:
+                "billable_sheets_of_paper" => 2,  // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+                "postage" => "first / second / europe / rest-of-world"  // optional string
+            ]
+        ]
+    ],
+    "links" => [
+        "current" => "/notifications?template_type=sms&status=delivered",
+        "next" => "/notifications?other_than=last_id_in_list&template_type=sms&status=delivered"
+    ]
 ];
 ```
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -632,6 +632,15 @@ You can then call different methods on this object to return the requested infor
 |#`response.created_at`|Date and time notification created|String|
 |#`response.completed_at`|Date and time notification delivered or failed|String|
 |#`response.created_by_name`|Name of sender if notification sent manually|String|
+|#`response.scheduled_for`|Date and time notification has been scheduled to be sent at|String|
+|#`response.one_click_unsubscribe`|URL that you provided so your recipients can unsubscribe (email only)|String|
+|#`response.is_cost_data_ready`|This field is true if cost data is ready, and false if it isn't|Boolean|
+|#`response.cost_in_pounds`|Cost of the notification in pounds. The cost does not take free allowance into account|Float|
+|#`response.cost_details.billable_sms_fragments`|Number of billable SMS fragments in your text message (SMS only)|Integer|
+|#`response.cost_details.international_rate_multiplier`|For international SMS rate is multiplied by this value (SMS only)|Integer|
+|#`response.cost_details.sms_rate`|Cost of 1 SMS fragment (SMS only)|Float|
+|#`response.cost_details.billable_sheets_of_paper`|Number of sheets of paper in the letter you sent, that you will be charged for (letter only)|Integer|
+|#`response.cost_details.postage`|Postage class of the notification sent (letter only)|String|
 
 #### Error codes
 
@@ -734,7 +743,8 @@ If you call the `collection` method on this object to return a notification arra
 |#`response.line_4`|Recipient address line 4 of the address (letter only)|String|
 |#`response.line_5`|Recipient address line 5 of the address (letter only)|String|
 |#`response.line_6`|Recipient address line 6 of the address (letter only)|String|
-|#`response.postcode`|Recipient postcode (letter only)|String|
+|#`response.line_7`|Recipient address line 7 of the address (letter only)|String|
+|#`response.postage`|Postage class of the notification sent (letter only)|String|
 |#`response.type`|Type of notification sent (sms, email or letter)|String|
 |#`response.status`|Notification status (sending / delivered / permanent-failure / temporary-failure / technical-failure)|String|
 |#`response.template`|Template UUID|String|
@@ -744,6 +754,15 @@ If you call the `collection` method on this object to return a notification arra
 |#`response.created_at`|Date and time notification created|String|
 |#`response.completed_at`|Date and time notification delivered or failed|String|
 |#`response.created_by_name`|Name of sender if notification sent manually|String|
+|#`response.scheduled_for`|Date and time notification has been scheduled to be sent at|String|
+|#`response.one_click_unsubscribe`|URL that you provided so your recipients can unsubscribe (email only)|String|
+|#`response.is_cost_data_ready`|This field is true if cost data is ready, and false if it isn't|Boolean|
+|#`response.cost_in_pounds`|Cost of the notification in pounds. The cost does not take free allowance into account|Float|
+|#`response.cost_details.billable_sms_fragments`|Number of billable SMS fragments in your text message (SMS only)|Integer|
+|#`response.cost_details.international_rate_multiplier`|For international SMS rate is multiplied by this value (SMS only)|Integer|
+|#`response.cost_details.sms_rate`|Cost of 1 SMS fragment (SMS only)|Float|
+|#`response.cost_details.billable_sheets_of_paper`|Number of sheets of paper in the letter you sent, that you will be charged for (letter only)|Integer|
+|#`response.cost_details.postage`|Postage class of the notification sent (letter only)|String|
 
 If the notification specified in the `older_than` argument is older than 7 days, the client returns an empty `collection` response.
 


### PR DESCRIPTION
## Summary
- Previously, we merged the data structure for the response for our python client [here](https://github.com/alphagov/notifications-tech-docs/pull/233)
- Here, we provide the same structure defined there and add the missing fields for our client documentation
- **Note**: that the existing documentation format was maintained for each client doc, but in the future we should look into making these consistent as now sometimes we define the responses as tables or json formatted which is inconsistent.


### Related task
[Add GET notification cost data to API clients and API client docs](https://trello.com/c/5VZrBNpU/845-3-add-get-notification-cost-data-to-api-clients-and-api-client-docs)