### PR TITLE
Add a setup section to the REST API documentation

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -4,14 +4,16 @@ This documentation is for developers interested in using the GOV.UK Notify API t
 
 You can use it to integrate directly with the API if you cannot use one of our 6 client libraries.
 
-## Base URL
+## Making a request
+
+### Base URL
 ```
 https://api.notifications.service.gov.uk
 ```
 
-## Headers
+### Headers
 
-### Authorisation header
+#### Authorisation header
 
 The authorisation header is an [API key](#api-keys) that is encoded using [JSON Web Tokens](https://jwt.io/). You must include an authorisation header.
 
@@ -58,7 +60,7 @@ When you have an encoded and signed token, add that token to a header as follows
 "Authorization": "Bearer encoded_jwt_token"
 ```
 
-### Content header
+#### Content header
 
 The content header is `application/json`:
 


### PR DESCRIPTION
All of our clients have a ‘Setting up the client’ section which includes subsections about installing dependencies, API keys, etc.

In the REST API documentation that information is at a level above, not within its own section.

This commit makes the REST API documentation consistent with the other clients, which should make it easier to navigate.

Before | After 
---|---
<img width="784" alt="image" src="https://github.com/user-attachments/assets/7019b9c5-d742-4b1c-9755-d86f11b225a8"> | <img width="786" alt="image" src="https://github.com/user-attachments/assets/68b587e8-b6a6-4d28-9a51-371f291791ac">

