### PR TITLE
Remove support section from documentation

### DIFF
--- a/source/documentation/_support.md
+++ b/source/documentation/_support.md
@@ -1,8 +1,0 @@
-## Support
-
-Report any problems via the [GOV.UK Notify support page](https://www.notifications.service.gov.uk/support).
-
-You can also:
-
-- check the [GOV.UK Notify system status page](https://status.notifications.service.gov.uk/)
-- ask the team on the GOV.UK Notify [Slack channel](https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC)

--- a/source/java.html.md.erb
+++ b/source/java.html.md.erb
@@ -10,4 +10,3 @@ parent: https://www.notifications.service.gov.uk/documentation
 <%= partial 'documentation/limits' %>
 <%= partial 'documentation/callbacks' %>
 <%= partial 'documentation/architecture' %>
-<%= partial 'documentation/support' %>

--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -10,4 +10,3 @@ parent: https://www.notifications.service.gov.uk/documentation
 <%= partial 'documentation/limits' %>
 <%= partial 'documentation/callbacks' %>
 <%= partial 'documentation/architecture' %>
-<%= partial 'documentation/support' %>

--- a/source/node.html.md.erb
+++ b/source/node.html.md.erb
@@ -10,4 +10,3 @@ parent: https://www.notifications.service.gov.uk/documentation
 <%= partial 'documentation/limits' %>
 <%= partial 'documentation/callbacks' %>
 <%= partial 'documentation/architecture' %>
-<%= partial 'documentation/support' %>

--- a/source/php.html.md.erb
+++ b/source/php.html.md.erb
@@ -10,4 +10,3 @@ parent: https://www.notifications.service.gov.uk/documentation
 <%= partial 'documentation/limits' %>
 <%= partial 'documentation/callbacks' %>
 <%= partial 'documentation/architecture' %>
-<%= partial 'documentation/support' %>

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -10,4 +10,3 @@ parent: https://www.notifications.service.gov.uk/documentation
 <%= partial 'documentation/limits' %>
 <%= partial 'documentation/callbacks' %>
 <%= partial 'documentation/architecture' %>
-<%= partial 'documentation/support' %>

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -10,4 +10,3 @@ parent: https://www.notifications.service.gov.uk/documentation
 <%= partial 'documentation/limits' %>
 <%= partial 'documentation/callbacks' %>
 <%= partial 'documentation/architecture' %>
-<%= partial 'documentation/support' %>

--- a/source/ruby.html.md.erb
+++ b/source/ruby.html.md.erb
@@ -10,4 +10,3 @@ parent: https://www.notifications.service.gov.uk/documentation
 <%= partial 'documentation/limits' %>
 <%= partial 'documentation/callbacks' %>
 <%= partial 'documentation/architecture' %>
-<%= partial 'documentation/support' %>


### PR DESCRIPTION
See discussion at: https://github.com/alphagov/notifications-tech-docs/pull/227#pullrequestreview-2101567237

David said:

> Controversially, I think we should get rid of this whole support section...
>
> The reason is that there is already a link at the top of the page which says 'support' and if you click on that it takes you to all this information already. Then it means we only have one place to keep up to date and consistent.
>
> My guess would be not many people would scroll down here to find information about support, when they will probably instead see 'support' at the top right too

Karl said:

> I agree.
>
> I was reminded that the Support link appears at the top of the docs when discussing an unrelated issue with Tom yesterday.

Closes #227