### PR TITLE
chore: php client include new notification fields (cost_in_pounds, is_data_ready and cost_details

### DIFF
--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -696,29 +696,44 @@ If the request to the client is successful, the client returns an `array`:
 
 ```php
 [
-    "id" => "notify_id",
-    "body" => "Hello Foo",
-    "subject" => "null|email_subject",
-    "reference" => "client reference",
-    "email_address" => "email address",
-    "phone_number" => "phone number",
-    "line_1" => "full name of a person or company",
-    "line_2" => "123 The Street",
-    "line_3" => "Some Area",
-    "line_4" => "Some Town",
-    "line_5" => "Some county",
-    "line_6" => "Something else",
-    "line_7" => "Postcode or country",
-    "postage" => "null|first|second",
-    "type" => "sms|letter|email",
-    "status" => "current status",
+    "id" => "740e5834-3a29-46b4-9a6f-16142fde533a", // required string - notification ID
+    "reference" => "STRING", // optional string - client reference
+    "email_address" => "sender@something.com", // required string for emails
+    "phone_number" => "+447900900123", // required string for text messages
+    "line_1" => "ADDRESS LINE 1", // required string for letter
+    "line_2" => "ADDRESS LINE 2", // required string for letter
+    "line_3" => "ADDRESS LINE 3", // required string for letter
+    "line_4" => "ADDRESS LINE 4", // optional string for letter
+    "line_5" => "ADDRESS LINE 5", // optional string for letter
+    "line_6" => "ADDRESS LINE 6", // optional string for letter
+    "line_7" => "ADDRESS LINE 7", // optional string for letter
+    "postage" => "first / second / europe / rest-of-world", // required string for letter
+    "type" => "sms / letter / email", // required string
+    "status" => "sending / delivered / permanent-failure / temporary-failure / technical-failure", // required string
     "template" => [
-        "version" => 1,
-        "id" => 1,
-        "uri" => "/template/{id}/{version}"
-     ],
-    "created_at" => "created at",
-    "sent_at" => "sent to provider at",
+        "version" => 1, // required integer
+        "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a", // required string - template ID
+        "uri" => "/v2/template/{id}/{version}" // required string
+    ],
+    "body" => "STRING", // required string - body of notification
+    "subject" => "STRING", // required string for email - subject of email
+    "created_at" => "2024-05-17 15:58:38.342838", // required string - date and time notification created
+    "created_by_name" => "STRING", // optional string - name of the person who sent the notification if sent manually
+    "sent_at" => "2024-05-17 15:58:30.143000", // optional string - date and time notification sent to provider
+    "completed_at" => "2024-05-17 15:59:10.321000", // optional string - date and time notification delivered or failed
+    "scheduled_for" => "2024-05-17 9:00:00.000000", // optional string - date and time notification has been scheduled to be sent at
+    "one_click_unsubscribe" => "STRING", // optional string, email only - URL that you provided so your recipients can unsubscribe
+    "is_cost_data_ready" => true, // required boolean, this field is true if cost data is ready, and false if it isn't
+    "cost_in_pounds" => 0.0027, // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+    "cost_details" => [
+        // for text messages:
+        "billable_sms_fragments" => 1, // optional integer - number of billable sms fragments in your text message
+        "international_rate_multiplier" => 1, // optional integer - for international sms rate is multiplied by this value
+        "sms_rate" => 0.0027, // optional number - cost of 1 sms fragment
+        // for letters:
+        "billable_sheets_of_paper" => 2, // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+        "postage" => "first / second / europe / rest-of-world" // optional string
+    ]
 ];
 ```
 
@@ -813,34 +828,51 @@ If the request to the client is successful, the client returns an `array`.
 ```php
 [
     "notifications" => [
-            "id" => "notify_id",
-            "reference" => "client reference",
-            "email_address" => "email address",
-            "phone_number" => "phone number",
-            "line_1" => "full name of a person or company",
-            "line_2" => "123 The Street",
-            "line_3" => "Some Area",
-            "line_4" => "Some Town",
-            "line_5" => "Some county",
-            "line_6" => "Something else",
-            "postcode" => "postcode",
-            "postage" => "null|first|second",
-            "type" => "sms | letter | email",
-            "status" => sending | delivered | permanent-failure | temporary-failure | technical-failure
+        [
+            "id" => "740e5834-3a29-46b4-9a6f-16142fde533a",  // required string - notification ID
+            "reference" => "STRING",  // optional string - client reference
+            "email_address" => "sender@something.com",  // required string for emails
+            "phone_number" => "+447900900123",  // required string for text messages
+            "line_1" => "ADDRESS LINE 1",  // required string for letter
+            "line_2" => "ADDRESS LINE 2",  // required string for letter
+            "line_3" => "ADDRESS LINE 3",  // required string for letter
+            "line_4" => "ADDRESS LINE 4",  // optional string for letter
+            "line_5" => "ADDRESS LINE 5",  // optional string for letter
+            "line_6" => "ADDRESS LINE 6",  // optional string for letter
+            "line_7" => "ADDRESS LINE 7",  // optional string for letter
+            "postage" => "first / second / europe / rest-of-world",  // required string for letter
+            "type" => "sms / letter / email",  // required string
+            "status" => "sending / delivered / permanent-failure / temporary-failure / technical-failure",  // required string
             "template" => [
-            "version" => 1,
-            "id" => 1,
-            "uri" => "/template/{id}/{version}"
-        ],
-        "created_at" => "created at",
-        "sent_at" => "sent to provider at",
-        ],
-        …
-  ],
-  "links" => [
-     "current" => "/notifications?template_type=sms&status=delivered",
-     "next" => "/notifications?older_than=last_id_in_list&template_type=sms&status=delivered"
-  ]
+                "version" => 1,  // required integer
+                "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",  // required string - template ID
+                "uri" => "/v2/template/{id}/{version}"  // required string
+            ],
+            "body" => "STRING",  // required string - body of notification
+            "subject" => "STRING",  // required string for email - subject of email
+            "created_at" => "2024-05-17 15:58:38.342838",  // required string - date and time notification created
+            "created_by_name" => "STRING",  // optional string - name of the person who sent the notification if sent manually
+            "sent_at" => "2024-05-17 15:58:30.143000",  // optional string - date and time notification sent to provider
+            "completed_at" => "2024-05-17 15:59:10.321000",  // optional string - date and time notification delivered or failed
+            "scheduled_for" => "2024-05-17 9:00:00.000000",  // optional string - date and time notification has been scheduled to be sent at
+            "one_click_unsubscribe" => "STRING",  // optional string, email only - URL that you provided so your recipients can unsubscribe
+            "is_cost_data_ready" => true,  // required boolean, this field is true if cost data is ready, and false if it isn't
+            "cost_in_pounds" => 0.0027,  // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+            "cost_details" => [
+                // for text messages:
+                "billable_sms_fragments" => 1,  // optional integer - number of billable sms fragments in your text message
+                "international_rate_multiplier" => 1,  // optional integer - for international sms rate is multiplied by this value
+                "sms_rate" => 0.0027,  // optional number - cost of 1 sms fragment
+                // for letters:
+                "billable_sheets_of_paper" => 2,  // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
+                "postage" => "first / second / europe / rest-of-world"  // optional string
+            ]
+        ]
+    ],
+    "links" => [
+        "current" => "/notifications?template_type=sms&status=delivered",
+        "next" => "/notifications?other_than=last_id_in_list&template_type=sms&status=delivered"
+    ]
 ];
 ```
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -715,7 +715,7 @@ If the request to the client is successful, the client returns an `array`:
     "template" => [
         "version" => 1,
         "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",
-        "uri" => "/v2/template/{id}/{version}"
+        "uri" => "/template/{id}/{version}"
     ],
     "body" => "STRING",
     "subject" => "STRING",
@@ -844,11 +844,11 @@ If the request to the client is successful, the client returns an `array`.
             "postcode" => "postcode",
             "postage" => "null|first|second",
             "type" => "sms | letter | email",
-            "status" => sending | delivered | permanent-failure | temporary-failure | technical-failure,
+            "status" => sending | delivered | permanent-failure | temporary-failure | technical-failure",
             "template" => [
                 "version" => 1,
                 "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",
-                "uri" => "/v2/template/{id}/{version}"
+                "uri" => "/template/{id}/{version}"
             ],
             "body" => "STRING",
             "subject" => "STRING",

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -696,43 +696,45 @@ If the request to the client is successful, the client returns an `array`:
 
 ```php
 [
-    "id" => "740e5834-3a29-46b4-9a6f-16142fde533a", // required string - notification ID
-    "reference" => "STRING", // optional string - client reference
-    "email_address" => "sender@something.com", // required string for emails
-    "phone_number" => "+447900900123", // required string for text messages
-    "line_1" => "ADDRESS LINE 1", // required string for letter
-    "line_2" => "ADDRESS LINE 2", // required string for letter
-    "line_3" => "ADDRESS LINE 3", // required string for letter
-    "line_4" => "ADDRESS LINE 4", // optional string for letter
-    "line_5" => "ADDRESS LINE 5", // optional string for letter
-    "line_6" => "ADDRESS LINE 6", // optional string for letter
-    "line_7" => "ADDRESS LINE 7", // optional string for letter
-    "postage" => "first / second / europe / rest-of-world", // required string for letter
-    "type" => "sms / letter / email", // required string
-    "status" => "sending / delivered / permanent-failure / temporary-failure / technical-failure", // required string
+    "id" => "notify_id",
+    "body" => "Hello Foo",
+    "subject" => "null|email_subject",
+    "reference" => "client reference",
+    "email_address" => "email address",
+    "phone_number" => "phone number",
+    "line_1" => "full name of a person or company",
+    "line_2" => "123 The Street",
+    "line_3" => "Some Area",
+    "line_4" => "Some Town",
+    "line_5" => "Some county",
+    "line_6" => "Something else",
+    "line_7" => "Postcode or country",
+    "postage" => "null|first|second",
+    "type" => "sms|letter|email",
+    "status" => "sending / delivered / permanent-failure / temporary-failure / technical-failure",
     "template" => [
-        "version" => 1, // required integer
-        "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a", // required string - template ID
-        "uri" => "/v2/template/{id}/{version}" // required string
+        "version" => 1,
+        "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",
+        "uri" => "/v2/template/{id}/{version}"
     ],
-    "body" => "STRING", // required string - body of notification
-    "subject" => "STRING", // required string for email - subject of email
-    "created_at" => "2024-05-17 15:58:38.342838", // required string - date and time notification created
-    "created_by_name" => "STRING", // optional string - name of the person who sent the notification if sent manually
-    "sent_at" => "2024-05-17 15:58:30.143000", // optional string - date and time notification sent to provider
-    "completed_at" => "2024-05-17 15:59:10.321000", // optional string - date and time notification delivered or failed
-    "scheduled_for" => "2024-05-17 9:00:00.000000", // optional string - date and time notification has been scheduled to be sent at
-    "one_click_unsubscribe" => "STRING", // optional string, email only - URL that you provided so your recipients can unsubscribe
-    "is_cost_data_ready" => true, // required boolean, this field is true if cost data is ready, and false if it isn't
-    "cost_in_pounds" => 0.0027, // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+    "body" => "STRING",
+    "subject" => "STRING",
+    "created_at" => "2024-05-17 15:58:38.342838",
+    "created_by_name" => "STRING",
+    "sent_at" => "2024-05-17 15:58:30.143000",
+    "completed_at" => "2024-05-17 15:59:10.321000",
+    "scheduled_for" => "2024-05-17 9:00:00.000000",
+    "one_click_unsubscribe" => "STRING",
+    "is_cost_data_ready" => true,
+    "cost_in_pounds" => 0.0027,
     "cost_details" => [
         // for text messages:
-        "billable_sms_fragments" => 1, // optional integer - number of billable sms fragments in your text message
-        "international_rate_multiplier" => 1, // optional integer - for international sms rate is multiplied by this value
-        "sms_rate" => 0.0027, // optional number - cost of 1 sms fragment
+        "billable_sms_fragments" => 1,
+        "international_rate_multiplier" => 1,
+        "sms_rate" => 0.0027,
         // for letters:
-        "billable_sheets_of_paper" => 2, // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
-        "postage" => "first / second / europe / rest-of-world" // optional string
+        "billable_sheets_of_paper" => 2,
+        "postage" => "first / second / europe / rest-of-world"
     ]
 ];
 ```
@@ -829,43 +831,43 @@ If the request to the client is successful, the client returns an `array`.
 [
     "notifications" => [
         [
-            "id" => "740e5834-3a29-46b4-9a6f-16142fde533a",  // required string - notification ID
-            "reference" => "STRING",  // optional string - client reference
-            "email_address" => "sender@something.com",  // required string for emails
-            "phone_number" => "+447900900123",  // required string for text messages
-            "line_1" => "ADDRESS LINE 1",  // required string for letter
-            "line_2" => "ADDRESS LINE 2",  // required string for letter
-            "line_3" => "ADDRESS LINE 3",  // required string for letter
-            "line_4" => "ADDRESS LINE 4",  // optional string for letter
-            "line_5" => "ADDRESS LINE 5",  // optional string for letter
-            "line_6" => "ADDRESS LINE 6",  // optional string for letter
-            "line_7" => "ADDRESS LINE 7",  // optional string for letter
-            "postage" => "first / second / europe / rest-of-world",  // required string for letter
-            "type" => "sms / letter / email",  // required string
-            "status" => "sending / delivered / permanent-failure / temporary-failure / technical-failure",  // required string
+            "id" => "notify_id",
+            "reference" => "client reference",
+            "email_address" => "email address",
+            "phone_number" => "phone number",
+            "line_1" => "full name of a person or company",
+            "line_2" => "123 The Street",
+            "line_3" => "Some Area",
+            "line_4" => "Some Town",
+            "line_5" => "Some county",
+            "line_6" => "Something else",
+            "postcode" => "postcode",
+            "postage" => "null|first|second",
+            "type" => "sms | letter | email",
+            "status" => sending | delivered | permanent-failure | temporary-failure | technical-failure,
             "template" => [
-                "version" => 1,  // required integer
-                "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",  // required string - template ID
-                "uri" => "/v2/template/{id}/{version}"  // required string
+                "version" => 1,
+                "id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",
+                "uri" => "/v2/template/{id}/{version}"
             ],
-            "body" => "STRING",  // required string - body of notification
-            "subject" => "STRING",  // required string for email - subject of email
-            "created_at" => "2024-05-17 15:58:38.342838",  // required string - date and time notification created
-            "created_by_name" => "STRING",  // optional string - name of the person who sent the notification if sent manually
-            "sent_at" => "2024-05-17 15:58:30.143000",  // optional string - date and time notification sent to provider
-            "completed_at" => "2024-05-17 15:59:10.321000",  // optional string - date and time notification delivered or failed
-            "scheduled_for" => "2024-05-17 9:00:00.000000",  // optional string - date and time notification has been scheduled to be sent at
-            "one_click_unsubscribe" => "STRING",  // optional string, email only - URL that you provided so your recipients can unsubscribe
-            "is_cost_data_ready" => true,  // required boolean, this field is true if cost data is ready, and false if it isn't
-            "cost_in_pounds" => 0.0027,  // optional number - cost of the notification in pounds. The cost does not take free allowance into account
+            "body" => "STRING",
+            "subject" => "STRING",
+            "created_at" => "2024-05-17 15:58:38.342838",
+            "created_by_name" => "STRING",
+            "sent_at" => "2024-05-17 15:58:30.143000",
+            "completed_at" => "2024-05-17 15:59:10.321000",
+            "scheduled_for" => "2024-05-17 9:00:00.000000",
+            "one_click_unsubscribe" => "STRING",
+            "is_cost_data_ready" => true,
+            "cost_in_pounds" => 0.0027,
             "cost_details" => [
                 // for text messages:
-                "billable_sms_fragments" => 1,  // optional integer - number of billable sms fragments in your text message
-                "international_rate_multiplier" => 1,  // optional integer - for international sms rate is multiplied by this value
-                "sms_rate" => 0.0027,  // optional number - cost of 1 sms fragment
+                "billable_sms_fragments" => 1,
+                "international_rate_multiplier" => 1,
+                "sms_rate" => 0.0027,
                 // for letters:
-                "billable_sheets_of_paper" => 2,  // optional integer - number of sheets of paper in the letter you sent, that you will be charged for
-                "postage" => "first / second / europe / rest-of-world"  // optional string
+                "billable_sheets_of_paper" => 2,
+                "postage" => "first / second / europe / rest-of-world"
             ]
         ]
     ],


### PR DESCRIPTION
## What problem does the pull request solve?
New fields have been added to the response of `get_notification(notificationId)` endpoint
- cost_in_pounds
- is_cost_data_ready
- cost_details:
-- **Nested fields for letters**:
--- billable_sheets_of_paper
--- postage
-- **Nested fields for sms**:
--- billable_sms_fragments
--- international_rate_multiplier
--- sms_rate
 
Based on the addition this PR updates our client documentation to showcase an aligned response for the endpoint

### Related task : 
[3. Add GET notification cost data to API clients and API client docs](https://trello.com/c/5VZrBNpU/845-3-add-get-notification-cost-data-to-api-clients-and-api-client-docs)