### PR TITLE
chore: update java docs to include new notification fields (cost_in_pounds, is_data_ready and cost_details)

### DIFF
--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -716,7 +716,7 @@ Optional<Integer> billableSmsFragments;
 Optional<Double> internationalRateMultiplier;
 Optional<Double> smsRate;
 Optional<Integer> billableSheetsOfPaper;
-Optional<String> costPostage;
+Optional<String> postageType;
 ```
 
 #### Error codes

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -704,12 +704,19 @@ UUID templateId;
 int templateVersion;
 String templateUri;
 String body;
-Optional<String subject;
+Optional<String> subject;
 ZonedDateTime createdAt;
 Optional<ZonedDateTime> sentAt;
 Optional<ZonedDateTime> completedAt;
 Optional<ZonedDateTime> estimatedDelivery;
 Optional<String> createdByName;
+boolean isCostDataReady;
+double costInPounds;
+Optional<Integer> billableSmsFragments;
+Optional<Double> internationalRateMultiplier;
+Optional<Double> smsRate;
+Optional<Integer> billableSheetsOfPaper;
+Optional<String> costPostage;
 ```
 
 #### Error codes


### PR DESCRIPTION
## What problem does the pull request solve?
New fields have been added to the response of `get_notification(notificationId)` endpoint
- cost_in_pounds
- is_cost_data_ready
- cost_details:
-- **Nested fields for letters**:
--- billable_sheets_of_paper
--- postage
-- **Nested fields for sms**:
--- billable_sms_fragments
--- international_rate_multiplier
--- sms_rate
 
Based on the addition this PR updates our client documentation to showcase an aligned response for the endpoint

### Related task : 
[3. Add GET notification cost data to API clients and API client docs](https://trello.com/c/5VZrBNpU/845-3-add-get-notification-cost-data-to-api-clients-and-api-client-docs)