### PR TITLE
chore: update net docs to include new notification fields (cost_in_pounds, is_data_ready and cost_details) response

### DIFF
--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -739,6 +739,9 @@ public String status;
 public Template template;
 public String type;
 public string createdByName;
+public bool isCostDataReady;  
+public double costInPounds;
+public CostDetails costDetails; 
 
 public class Template
 {
@@ -747,7 +750,22 @@ public class Template
     public Int32 version;
 }
 
+public class CostDetails
+{
+    [JsonProperty("billable_sms_fragments")]
+    public int? billableSmsFragments;
 
+    [JsonProperty("international_rate_multiplier")]
+    public double? internationalRateMultiplier;
+
+    [JsonProperty("sms_rate")]
+    public double? smsRate;
+
+    [JsonProperty("billable_sheets_of_paper")]
+    public int? billableSheetsOfPaper;
+
+    public string? postage;
+}
 ```
 
 #### Error codes

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -764,7 +764,7 @@ public class CostDetails
     [JsonProperty("billable_sheets_of_paper")]
     public int? billableSheetsOfPaper;
 
-    public string? postage;
+    public string postage;
 }
 ```
 


### PR DESCRIPTION
New fields have been added to the response of `get_notification(notificationId)` endpoint
- cost_in_pounds
- is_cost_data_ready
- cost_details:
-- **Nested fields for letters**:
--- billable_sheets_of_paper
--- postage
-- **Nested fields for sms**:
--- billable_sms_fragments
--- international_rate_multiplier
--- sms_rate
 
Based on the addition this PR updates our client documentation to showcase an aligned response for the endpoint

### Related task : 
[3. Add GET notification cost data to API clients and API client docs](https://trello.com/c/5VZrBNpU/845-3-add-get-notification-cost-data-to-api-clients-and-api-client-docs)