### PR TITLE
One click unsub update

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -244,21 +244,38 @@ An identifier you can create if necessary. This reference identifies a single no
 ```
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (optional)
+##### one_click_unsubscribe_url (required)
+
+If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
-
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```json
 "one_click_unsubscribe_url": "https://example.com/unsubscribe.html?opaque=123456789"
 ```
-
 The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
 You can leave out this argument if the email being sent is not a subscription email.
+
+##### Unsubscribe link at the bottom of the email (recommended)
+
+To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
+
+Use this example if you have a webpage for users to manage their email subscriptions:
+
+```json
+[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+```
+Your webpage should ask the recipients to confirm that they want to unsubscribe. 
+
+If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+
+```json
+[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+```
+The email address should be a shared inbox managed by your team, not your own email address.
 
 ##### email_reply_to_id (optional)
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -212,11 +212,11 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference='STRING';
 ```
 
-##### oneClickUnsubscribeURL (optional)
+##### oneClickUnsubscribeURL (required)
+
+If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
-
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```java
 URI oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'
@@ -227,6 +227,24 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
 You can leave out this argument if the email being sent is not a subscription email.
+
+##### Unsubscribe link at the bottom of the email (recommended)
+
+To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
+
+Use this example if you have a webpage for users to manage their email subscriptions:
+
+```java
+[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+```
+Your webpage should ask the recipients to confirm that they want to unsubscribe. 
+
+If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+
+```java
+[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+```
+The email address should be a shared inbox managed by your team, not your own email address.
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -268,11 +268,11 @@ string reference: "STRING";
 ```
 You can leave out this argument if you do not have a reference.
 
-##### oneClickUnsubscribeURL (optional)
+##### oneClickUnsubscribeURL (required)
+
+If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
-
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```csharp
 string oneClickUnsubscribeURL : 'https://example.com/unsubscribe.html?opaque=123456789';
@@ -283,6 +283,24 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
 You can leave out this argument if the email being sent is not a subscription email.
+
+##### Unsubscribe link at the bottom of the email (recommended)
+
+To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
+
+Use this example if you have a webpage for users to manage their email subscriptions:
+
+```csharp
+[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+```
+Your webpage should ask the recipients to confirm that they want to unsubscribe. 
+
+If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+
+```csharp
+[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+```
+The email address should be a shared inbox managed by your team, not your own email address.
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -246,11 +246,11 @@ A unique identifier you create. This reference identifies a single unique notifi
 "your_reference_here"
 ```
 
-##### oneClickUnsubscribeURL (optional)
+##### oneClickUnsubscribeURL (required)
+
+If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
-
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```javascript
 oneClickUnsubscribeURL = 'https://example.com/unsubscribe.html?opaque=123456789'
@@ -261,6 +261,24 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
 You can leave out this argument if the email being sent is not a subscription email.
+
+##### Unsubscribe link at the bottom of the email (recommended)
+
+To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
+
+Use this example if you have a webpage for users to manage their email subscriptions:
+
+```java
+[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+```
+Your webpage should ask the recipients to confirm that they want to unsubscribe. 
+
+If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+
+```java
+[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+```
+The email address should be a shared inbox managed by your team, not your own email address.
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -216,11 +216,11 @@ $reference = 'STRING';
 ```
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (optional)
+##### one_click_unsubscribe_url (required)
+
+If you send subscription emails you must let recipients opt out of receiving themThe one-click. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
-
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 
 ```php
 $one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456789'
@@ -229,6 +229,24 @@ $one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456
 The one-click unsubscribe URL must respond to an empty `POST` request by unsubscribing the user from your emails. You can include query parameters to help you identify the user.
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
+
+##### Unsubscribe link at the bottom of the email (recommended)
+
+To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
+
+Use this example if you have a webpage for users to manage their email subscriptions:
+
+```php
+[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+```
+Your webpage should ask the recipients to confirm that they want to unsubscribe. 
+
+If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+
+```php
+[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+```
+The email address should be a shared inbox managed by your team, not your own email address.
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -195,11 +195,11 @@ reference='STRING', # optional string - identifies notification(s)
 
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (optional)
+##### one_click_unsubscribe_url (required)
+
+If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
-
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```python
 one_click_unsubscribe_url = 'https://example.com/unsubscribe.html?opaque=123456789'
@@ -210,6 +210,24 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
 You can leave out this argument if the email being sent is not a subscription email.
+
+##### Unsubscribe link at the bottom of the email (recommended)
+
+To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
+
+Use this example if you have a webpage for users to manage their email subscriptions:
+
+```python
+[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+```
+Your webpage should ask the recipients to confirm that they want to unsubscribe. 
+
+If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+
+```python
+[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+```
+The email address should be a shared inbox managed by your team, not your own email address.
 
 ##### email_reply_to_id (optional)
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -203,11 +203,11 @@ reference: "your_reference_string"
 
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (optional)
+##### one_click_unsubscribe_url (required)
+
+If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
-
-Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 
 ```ruby
 one_click_unsubscribe_url: "https://example.com/unsubscribe.html?opaque=123456789"
@@ -218,6 +218,25 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
 You can leave out this argument if the email being sent is not a subscription email.
+
+##### Unsubscribe link at the bottom of the email (recommended)
+
+To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
+
+Use this example if you have a webpage for users to manage their email subscriptions:
+
+```ruby
+[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+```
+Your webpage should ask the recipients to confirm that they want to unsubscribe. 
+
+If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+
+```ruby
+[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+```
+The email address should be a shared inbox managed by your team, not your own email address.
+
 
 ##### email_reply_to_id (optional)
 


### PR DESCRIPTION
Updated to add unsubscribe links markdown at the bottom of subscription emails.

User will need to add this with the one-click unsubscribe in the header of emails in API.