### PR TITLE
Update one click unsubscribe argument from required to recommended and update some headings

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -1018,7 +1018,7 @@ If the request is not successful, the API returns `json` containing the relevant
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
-### Get a PDF for a letter
+### Get a PDF for a letter notification
 
 This returns the PDF contents of a letter.
 

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -246,7 +246,7 @@ An identifier you can create if necessary. This reference identifies a single no
 ```
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (required)
+##### one_click_unsubscribe_url (recommended)
 
 If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -26,6 +26,8 @@ NotificationClient client = new NotificationClient(apiKey);
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
+#### Connect through a proxy (optional)
+
 If you use a proxy you can pass it into the NotificationClient constructor.
 
 ```java

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -214,7 +214,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference='STRING';
 ```
 
-##### oneClickUnsubscribeURL (required)
+##### oneClickUnsubscribeURL (recommended)
 
 If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -47,7 +47,7 @@ Run the following in the NuGet package manager console to install the client pac
 nuget install GovukNotify
 ```
 
-##### UI
+##### User Interface (UI)
 
 Use the Package Manager UI to [search for and install the client package](https://docs.microsoft.com/en-us/nuget/tools/package-manager-ui#finding-and-installing-a-package).
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -270,7 +270,7 @@ string reference: "STRING";
 ```
 You can leave out this argument if you do not have a reference.
 
-##### oneClickUnsubscribeURL (required)
+##### oneClickUnsubscribeURL (recommended)
 
 If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -65,6 +65,8 @@ var client = new NotificationClient(apiKey);
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
+#### Connect through a proxy (optional)
+
 If you use a proxy, you must set the proxy configuration in the `web.config` file. Refer to the [Microsoft documentation on proxy configuration](https://docs.microsoft.com/en-us/dotnet/framework/network-programming/proxy-configuration) for more information.
 
 ```csharp

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -246,7 +246,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 "your_reference_here"
 ```
 
-##### oneClickUnsubscribeURL (required)
+##### oneClickUnsubscribeURL (recommended)
 
 If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -216,7 +216,7 @@ $reference = 'STRING';
 ```
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (required)
+##### one_click_unsubscribe_url (recommended)
 
 If you send subscription emails you must let recipients opt out of receiving themThe one-click. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links). 
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -195,7 +195,7 @@ reference='STRING', # optional string - identifies notification(s)
 
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (required)
+##### one_click_unsubscribe_url (recommended)
 
 If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -924,7 +924,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
-### Get a PDF for a letter
+### Get a PDF for a letter notification
 
 #### Method
 
@@ -1214,7 +1214,7 @@ If the request to the client is successful, the client will return a `<generator
 <generator object NotificationsAPIClient.get_received_texts_iterator at 0x1026c7410>
 ```
 
-### Get one page of received text messages
+### Get a page of received text messages
 
 This will return one page of up to 250 text messages.
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -203,7 +203,7 @@ reference: "your_reference_string"
 
 You can leave out this argument if you do not have a reference.
 
-##### one_click_unsubscribe_url (required)
+##### one_click_unsubscribe_url (recommended)
 
 If you send subscription emails you must let recipients opt out of receiving them. Read our Using Notify page for more information about [unsubscribe links](https://www.notifications.service.gov.uk/using-notify/unsubscribe-links).
 


### PR DESCRIPTION
Updated headings to align across API docs (including missing headings, inconsistently named headings)

Also update the one click unsubscribe argument - it said it's required previously, but the send_email request will succeed without it. So we say it's recommended now.
