### PR TITLE
One click unsubscribe guidance re-draft

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -261,23 +261,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-##### Unsubscribe link at the bottom of the email (recommended)
-
-To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
-
-Use this example if you have a webpage for users to manage their email subscriptions:
-
-```json
-[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-```
-Your webpage should ask the recipients to confirm that they want to unsubscribe. 
-
-If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-
-```json
-[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-```
-The email address should be a shared inbox managed by your team, not your own email address.
+You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### email_reply_to_id (optional)
 

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -263,6 +263,8 @@ You can leave out this argument if the email being sent is not a subscription em
 
 You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
 
+Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
+
 ##### email_reply_to_id (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -261,7 +261,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
 
 ##### email_reply_to_id (optional)
 

--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -261,7 +261,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email should take the email recipient to a webpage where they can confirm that they want to unsubscribe.  
 
 Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -230,23 +230,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-##### Unsubscribe link at the bottom of the email (recommended)
-
-To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
-
-Use this example if you have a webpage for users to manage their email subscriptions:
-
-```java
-[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-```
-Your webpage should ask the recipients to confirm that they want to unsubscribe. 
-
-If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-
-```java
-[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-```
-The email address should be a shared inbox managed by your team, not your own email address.
+You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -230,7 +230,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.   
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email should take the email recipient to a webpage where they can confirm that they want to unsubscribe.  
 
 Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -230,7 +230,9 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.   
+
+Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -232,7 +232,7 @@ You can leave out this argument if the email being sent is not a subscription em
 
 You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.   
 
-Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
+Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -286,23 +286,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-##### Unsubscribe link at the bottom of the email (recommended)
-
-To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
-
-Use this example if you have a webpage for users to manage their email subscriptions:
-
-```csharp
-[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-```
-Your webpage should ask the recipients to confirm that they want to unsubscribe. 
-
-If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-
-```csharp
-[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-```
-The email address should be a shared inbox managed by your team, not your own email address.
+You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -286,7 +286,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email should take the email recipient to a webpage where they can confirm that they want to unsubscribe.  
 
 Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -286,7 +286,9 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+
+Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -264,6 +264,10 @@ You can leave out this argument if the email being sent is not a subscription em
 
 You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+
+Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
+
 ##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -264,7 +264,7 @@ You can leave out this argument if the email being sent is not a subscription em
 
 You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
-You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email should take the email recipient to a webpage where they can confirm that they want to unsubscribe.  
 
 Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -262,23 +262,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-##### Unsubscribe link at the bottom of the email (recommended)
-
-To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
-
-Use this example if you have a webpage for users to manage their email subscriptions:
-
-```java
-[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-```
-Your webpage should ask the recipients to confirm that they want to unsubscribe. 
-
-If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-
-```java
-[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-```
-The email address should be a shared inbox managed by your team, not your own email address.
+You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -230,7 +230,7 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
-You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email should take the email recipient to a webpage where they can confirm that they want to unsubscribe.  
 
 Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -230,7 +230,9 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
-You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+
+Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -230,23 +230,7 @@ The one-click unsubscribe URL must respond to an empty `POST` request by unsubsc
 
 Your unsubscribe URL and response must comply with the guidance specified in [Section 3.1 of IETF RFC 8058](https://www.rfcreader.com/#rfc8058_line139).
 
-##### Unsubscribe link at the bottom of the email (recommended)
-
-To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
-
-Use this example if you have a webpage for users to manage their email subscriptions:
-
-```php
-[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-```
-Your webpage should ask the recipients to confirm that they want to unsubscribe. 
-
-If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-
-```php
-[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-```
-The email address should be a shared inbox managed by your team, not your own email address.
+You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### emailReplyToId (optional)
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -211,23 +211,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-##### Unsubscribe link at the bottom of the email (recommended)
-
-To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
-
-Use this example if you have a webpage for users to manage their email subscriptions:
-
-```python
-[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-```
-Your webpage should ask the recipients to confirm that they want to unsubscribe. 
-
-If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-
-```python
-[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-```
-The email address should be a shared inbox managed by your team, not your own email address.
+You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### email_reply_to_id (optional)
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -211,7 +211,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email should take the email recipient to a webpage where they can confirm that they want to unsubscribe.  
 
 Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -211,7 +211,9 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+
+Find out how to add a link when you create a __New template__ or __Edit__ an email template. 
 
 ##### email_reply_to_id (optional)
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -219,7 +219,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email should take the email recipient to a webpage where they can confirm that they want to unsubscribe.  
 
 Find out how to add a link when you create a __New template__ or __Edit__ an email template.  
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -219,7 +219,9 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
+You must also add an unsubscribe link to the bottom of your email. The unsubscribe link at the bottom of your email must be a `GET` request. Your link should go to a webpage where the recipient can confirm that they want to unsubscribe.  
+
+Find out how to add a link when you create a __New template__ or __Edit__ an email template.  
 
 ##### email_reply_to_id (optional)
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -219,24 +219,7 @@ Your unsubscribe URL and response must comply with the guidance specified in [Se
 
 You can leave out this argument if the email being sent is not a subscription email.
 
-##### Unsubscribe link at the bottom of the email (recommended)
-
-To add an unsubscribe link at the bottom of your email, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.
-
-Use this example if you have a webpage for users to manage their email subscriptions:
-
-```ruby
-[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-```
-Your webpage should ask the recipients to confirm that they want to unsubscribe. 
-
-If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-
-```ruby
-[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-```
-The email address should be a shared inbox managed by your team, not your own email address.
-
+You should also add an unsubscribe link to the bottom of your email. Find out how to add an unsubscribe link when you create a __New template__ or __Edit__ an email template. 
 
 ##### email_reply_to_id (optional)
 


### PR DESCRIPTION
Re-drafted guidance on adding a one click unsubscribe link in the email body - basic guidance on what to do.