### PR TITLE
Add returned letters callback

### DIFF
--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -65,7 +65,7 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 
 ### Returned letters
 
-When a letter you sent is returned, Notify will send details of the returned letter to your callback url.
+When a letter you sent is returned, Notify will send details of the returned letter to your callback URL.
 
 Find more [information about returned letters](https://www.notifications.service.gov.uk/using-notify/delivery-times#returned-mail).  It can take a few weeks to receive information about a returned letter.
 

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -4,6 +4,7 @@ Callbacks are when GOV.UK Notify sends `POST` requests to your service. You can 
 
 - a text message or email you’ve sent is delivered or fails
 - your service receives a text message
+- a letter you sent is returned
 
 ### Set up callbacks
 
@@ -60,3 +61,25 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 |#`destination_number` | The number the message was sent to (your number) | 07700987654|
 |#`message` | The received message | Hello Notify!|
 |#`date_received` | The UTC datetime that the message was received by Notify | 2017-05-14T12:15:30.000000Z|
+
+
+### Returned letters
+
+When a letter you sent is returned, Notify will send details of the returned letter to your callback url.
+
+Find more [information about returned letters](https://www.notifications.service.gov.uk/using-notify/delivery-times#returned-mail).  It can take a few weeks to receive information about a returned letter.
+
+The callback message is formatted in JSON. All of the values are strings. The key, description and format of the callback message arguments will be:
+
+| Key | Description | Format |
+|:---|:---|:---|
+| #`notification_id` | Notify’s id for the returned letter | UUID |
+| #`reference` | The reference sent by the service | `12345678` or null |
+| #`date_sent` | The time the letter was sent | `2017-05-14T12:15:30.000000Z` |
+| #`sent_by` | The email address of the service member who sent the letter | `hello@gov.uk`|
+| #`template_name` | The name of the template that was used | `Template name` |
+| #`template_id` | The id of the template that was used | UUID |
+| #`template_version` | The version number of the template that was used | `1` |
+| #`spreadsheet_file_name`| The name of the uploaded spreadsheet | `contact_list.csv` |
+| #`spreadsheet_row_number`| The row in the spreadsheet  | `1` |
+| #`upload_letter_file_name`| The name of the uploaded letter | `uploaded_letter.pdf` |

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -73,7 +73,7 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 
 | Key | Description | Format |
 |:---|:---|:---|
-| #`notification_id` | Notify’s id for the returned letter | UUID |
+| #`notification_id` | Notify’s ID for the returned letter | UUID |
 | #`reference` | The reference sent by the service | `12345678` or null |
 | #`date_sent` | The time the letter was sent | `2017-05-14T12:15:30.000000Z` |
 | #`sent_by` | The email address of the service member who sent the letter | `hello@gov.uk`|

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -81,5 +81,5 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 | #`template_id` | The id of the template that was used | UUID |
 | #`template_version` | The version number of the template that was used | `1` |
 | #`spreadsheet_file_name`| The name of the uploaded spreadsheet | `contact_list.csv` |
-| #`spreadsheet_row_number`| The row in the spreadsheet  | `1` |
+| #`spreadsheet_row_number`| The row in the spreadsheet  | `2` or null |
 | #`upload_letter_file_name`| The name of the uploaded letter | `uploaded_letter.pdf` |

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -76,7 +76,7 @@ The callback message is formatted in JSON. The key, description and format of th
 | #`notification_id` | Notify’s ID for the returned letter | UUID |
 | #`reference` | The reference sent by the service | `12345678` or null |
 | #`date_sent` | The time the letter was sent | `2017-05-14T12:15:30.000000Z` |
-| #`sent_by` | The email address of the service member who sent the letter | `hello@gov.uk`|
+| #`sent_by` | The email address of the service member who sent the letter | `hello@gov.uk` or null |
 | #`template_name` | The name of the template that was used | `Template name` |
 | #`template_id` | The id of the template that was used | UUID |
 | #`template_version` | The version number of the template that was used | `1` |

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -82,4 +82,4 @@ The callback message is formatted in JSON. The key, description and format of th
 | #`template_version` | The version number of the template that was used | `1` |
 | #`spreadsheet_file_name`| The name of the uploaded spreadsheet | `contact_list.csv`  or null |
 | #`spreadsheet_row_number`| The row in the spreadsheet  | `2` or null |
-| #`upload_letter_file_name`| The name of the uploaded letter | `uploaded_letter.pdf` |
+| #`upload_letter_file_name`| The name of the uploaded letter | `uploaded_letter.pdf`  or null |

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -80,6 +80,6 @@ The callback message is formatted in JSON. The key, description and format of th
 | #`template_name` | The name of the template that was used | `Template name` |
 | #`template_id` | The id of the template that was used | UUID |
 | #`template_version` | The version number of the template that was used | `1` |
-| #`spreadsheet_file_name`| The name of the uploaded spreadsheet | `contact_list.csv` |
+| #`spreadsheet_file_name`| The name of the uploaded spreadsheet | `contact_list.csv`  or null |
 | #`spreadsheet_row_number`| The row in the spreadsheet  | `2` or null |
 | #`upload_letter_file_name`| The name of the uploaded letter | `uploaded_letter.pdf` |

--- a/source/documentation/_callbacks.md
+++ b/source/documentation/_callbacks.md
@@ -69,7 +69,7 @@ When a letter you sent is returned, Notify will send details of the returned let
 
 Find more [information about returned letters](https://www.notifications.service.gov.uk/using-notify/delivery-times#returned-mail).  It can take a few weeks to receive information about a returned letter.
 
-The callback message is formatted in JSON. All of the values are strings. The key, description and format of the callback message arguments will be:
+The callback message is formatted in JSON. The key, description and format of the callback message arguments will be:
 
 | Key | Description | Format |
 |:---|:---|:---|


### PR DESCRIPTION
This PR is a draft documentation of the proposed API callback for returned letters as described in this [card](https://trello.com/c/MqwEyn03/155-write-draft-documentation-for-api-callbacks-for-returned-letters)
<img width="1491" alt="returned letters callback 1" src="https://github.com/user-attachments/assets/780dd4e2-bb09-4412-bacd-cd52f0bbced3">

<img width="1275" alt="returned letters" src="https://github.com/user-attachments/assets/5a25c117-d18b-422e-b6e6-ad077b05f8a7">

