### PR TITLE
Clarify returned data time span for multiple messages statuses

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -812,7 +812,7 @@ If the request is not successful, the API returns `json` containing the relevant
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
 ```
 GET /v2/notifications

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -750,7 +750,7 @@ If the request is not successful, the client returns a `NotificationClientExcept
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThanId`](#olderthanid-optional) argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
 #### Method
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -799,7 +799,7 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 
 This API call returns the status of multiple messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `olderThanId` argument.
 
-You can only get messages that are 7 days old or newer.
+You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
 #### Method
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -821,7 +821,7 @@ If the request is not successful, the promise fails with an `err`.
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThan`](#olderthan-optional) argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
 #### Method
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -768,7 +768,7 @@ If the request is not successful, the client will return an `Alphagov\Notificati
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
 #### Method
 


### PR DESCRIPTION
It turns out that for service's retention period applies when querying for notifications status of multile messages and not 7 days as we state. User raised this

Omitted python and ruby as fixes for that are in #264 