### PR TITLE
Change port mapping to use the loopback address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ bootstrap-with-docker: ## Prepare the Docker builder image
 
 .PHONY: run-with-docker
 run-with-docker: ## Runs the app with Docker
-	export DOCKER_ARGS="-p 4567:4567 -p 35729:35729" && \
+	export DOCKER_ARGS="-p 127.0.0.1:4567:4567 -p 127.0.0.1:35729:35729" && \
 		./scripts/run_with_docker.sh make run
 
 .PHONY: development

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
+.DEFAULT_GOAL := help
 SHELL := /bin/bash
+
+.PHONY: help
+help:
+	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: bootstrap
 bootstrap: ## Install dependencies
@@ -9,7 +14,7 @@ run: development generate-tech-docs-yml ## Runs the app in development
 	bundle exec middleman server
 
 .PHONY: generate-tech-docs-yml
-generate-tech-docs-yml:
+generate-tech-docs-yml: ## Generate the tech-docs.yml file
 	@erb config/tech-docs.yml.erb > config/tech-docs.yml
 
 .PHONY: bootstrap-with-docker
@@ -17,7 +22,7 @@ bootstrap-with-docker: ## Prepare the Docker builder image
 	docker build -f docker/Dockerfile --target ruby_build -t notifications-tech-docs .
 
 .PHONY: run-with-docker
-run-with-docker:
+run-with-docker: ## Runs the app with Docker
 	export DOCKER_ARGS="-p 4567:4567 -p 35729:35729" && \
 		./scripts/run_with_docker.sh make run
 


### PR DESCRIPTION
Docker defaults to using `0.0.0.0`, the default route listening on all
network interfaces, as opposed to the loopback address (`127.0.0.1`).
This has security implications and we have been asked to change it.

We made this change for all other apps last year, (for example
https://github.com/alphagov/notifications-antivirus/pull/170) but forgot this one.