### PR TITLE
Add placeholder injection guidance

### DIFF
--- a/source/documentation/_api_docs.md
+++ b/source/documentation/_api_docs.md
@@ -266,6 +266,8 @@ If a template has placeholder fields for personalised information such as name o
 ```
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
+Find out how to [reduce the risk of malicious content injection in placeholders](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
 ##### reference (optional)
 
 An identifier you can create if necessary. This reference identifies a single unique email or a batch of emails. It must not contain any personal information such as name or postal address. For example:
@@ -336,6 +338,45 @@ If the request is successful, the response body is `json` with a status code of 
   }
 }
 ```
+
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown. 
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify. 
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML 
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+**Template in Notify**:
+
+```
+Hello ((name))
+```
+
+**Personalisation**: 
+
+```
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+**Email will appear as**: 
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content. 
+You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape). 
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 #### Error codes
 

--- a/source/documentation/client_docs/_java.md
+++ b/source/documentation/client_docs/_java.md
@@ -206,6 +206,8 @@ personalisation.put("list", listOfItems);
 
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
 
+Find out how to [reduce the risk of malicious content injection in placeholders](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
 ##### reference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. If you do not have a reference, you must pass in an empty string or `null`.
@@ -267,6 +269,44 @@ String body;
 String subject;
 Optional<String> fromEmail;
 ```
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown. 
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify. 
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML 
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+**Template in Notify**:
+
+```java
+Hello ((name))
+```
+
+**Personalisation**: 
+
+```java
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+**Email will appear as**: 
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content. 
+You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape). 
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 #### Error codes
 

--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -261,6 +261,8 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
+Find out how to [reduce the risk of malicious content injection in placeholders](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
 ##### reference (optional)
 
 A unique identifier you can create if you need to. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
@@ -333,6 +335,44 @@ public class EmailResponseContent{
   public String subject;
 }
 ```
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown. 
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify. 
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML 
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+**Template in Notify**:
+
+```csharp
+Hello ((name))
+```
+
+**Personalisation**: 
+
+```csharp
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+**Email will appear as**: 
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content. 
+You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape). 
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 #### Error codes
 

--- a/source/documentation/client_docs/_node.md
+++ b/source/documentation/client_docs/_node.md
@@ -253,6 +253,8 @@ let options = {
 
 Note: if you pass a list like `required_documents` in the example above, it will appear as bullet points in your message.
 
+Find out how to [reduce the risk of malicious content injection in placeholders](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
 ##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique email or a batch of emails. It must not contain any personal information such as name or postal address. For example:
@@ -330,6 +332,44 @@ If the request is successful, the promise resolves with a `response` `object`. F
     }
 };
 ```
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown. 
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify. 
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML 
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+**Template in Notify**:
+
+```javascript
+Hello ((name))
+```
+
+**Personalisation**: 
+
+```javascript
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+**Email will appear as**: 
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content. 
+You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape). 
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 #### Error codes
 

--- a/source/documentation/client_docs/_php.md
+++ b/source/documentation/client_docs/_php.md
@@ -207,6 +207,8 @@ $personalisation = [
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
+Find out how to [reduce the risk of malicious content injection in placeholders](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
 ##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
@@ -253,6 +255,44 @@ $emailReplyToId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 ```
 
 You can leave out this argument if your service only has one email reply-to address, or you want to use the default email address.
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown. 
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify. 
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML 
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+**Template in Notify**:
+
+```php
+Hello ((name))
+```
+
+**Personalisation**: 
+
+```php
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+**Email will appear as**: 
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content. 
+You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape). 
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 ### Send a file by email
 

--- a/source/documentation/client_docs/_python.md
+++ b/source/documentation/client_docs/_python.md
@@ -211,6 +211,8 @@ personalisation={
 ```
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
+Find out how to [reduce the risk of malicious content injection in placeholders](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
 ##### reference (optional)
 
 An identifier you can create if necessary. This reference identifies a single unique email or a batch of emails. It must not contain any personal information such as name or postal address. For example:
@@ -283,6 +285,44 @@ If the request to the client is successful, the client returns a `dict`:
   }
 }
 ```
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown. 
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify. 
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML 
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+**Template in Notify**:
+
+```python
+Hello ((name))
+```
+
+**Personalisation**: 
+
+```python
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+**Email will appear as**: 
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content. 
+You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape). 
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 ### Send a file by email
 

--- a/source/documentation/client_docs/_ruby.md
+++ b/source/documentation/client_docs/_ruby.md
@@ -193,6 +193,8 @@ personalisation: {
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
+Find out how to [reduce the risk of malicious content injection in placeholders](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
 ##### reference (optional)
 
 A unique identifier you can create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
@@ -240,6 +242,44 @@ For example:
 ```ruby
 email_reply_to_id: '8e222534-7f05-4972-86e3-17c5d9f894e2'
 ```
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown. 
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify. 
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML 
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+**Template in Notify**:
+
+```ruby
+Hello ((name))
+```
+
+**Personalisation**: 
+
+```ruby
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+**Email will appear as**: 
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content. 
+You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape). 
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
+
 
 You can leave out this argument if your service only has one email reply-to address, or you want to use the default email address.
 


### PR DESCRIPTION
This PR adds a section on placeholder injection to the tech docs as described in [this](https://trello.com/c/b1CpDIxu/238-add-a-section-to-our-tech-docs-about-how-to-handle-user-input) card.

The aim is to explain what the issue is and offer a means of mitigation. The team is working on deploying a solution on our end in the not to distant future.