### PR TITLE
Update daily text message limits to include default international text message limit

### DIFF
--- a/source/documentation/_limits.md
+++ b/source/documentation/_limits.md
@@ -12,7 +12,8 @@ There’s a limit to the number of messages you can send each day:
 
 |Service status|Type of API key|Daily limit|
 |:---|:---|:---|
-|Live|Team or live|<ul class="govuk-list govuk-!-font-size-16"><li>250,000 emails</li><li>250,000 text messages</li><li>20,000 letters</li></ul>|
+|Live|Team or live|<ul class="govuk-list govuk-!-font-size-16"><li>250,000 emails</li><li>250,000 text messages, including a default 100 international text messages
+</li><li>20,000 letters</li></ul>|
 |Trial|Team|50 emails or text messages|
 |Live or trial|Test|Unlimited|
 


### PR DESCRIPTION
Update daily text message limits to include 100 default international text message 