### PR TITLE
Remove warning about installing older versions of .NET client

### DIFF
--- a/source/documentation/client_docs/_net.md
+++ b/source/documentation/client_docs/_net.md
@@ -16,15 +16,6 @@ The GOV.UK Notify client can be installed from [Nuget.org](https://www.nuget.org
 
 You can install the GOV.UK Notify client package using either the command line or Microsoft Visual Studio.
 
-<div class="govuk-warning-text">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-      If you need a version of our API client older than 4.0.0, you should download it from
-      <a href="https://github.com/alphagov/notifications-net-client/releases">Github</a> [external link]
-  </strong>
-</div>
-
 #### Use the dotnet command line interface
 
 Go to your project directory and run the following in the command line to install the client package:


### PR DESCRIPTION
We released version 4.0.0 in 2021 so enough time should now have passed that we don’t need to tell people how to get older versions than that