### PR TITLE
[DO NOT MERGE UNTIL 25 JUNE] Upgrade gem to v5 to enable rebrand

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'govuk_tech_docs', '~> 4.3.1'
+gem 'govuk_tech_docs', '~> 5.0.2'
 gem 'mini_racer', '~> 0.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GEM
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     backports (3.25.1)
-    base64 (0.2.0)
-    bigdecimal (3.1.9)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
     chronic (0.10.2)
     chunky_png (1.4.0)
     coffee-script (2.4.1)
@@ -34,7 +34,7 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.3.4)
     contracts (0.16.1)
-    csv (3.3.4)
+    csv (3.3.5)
     dotenv (3.1.8)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -44,19 +44,11 @@ GEM
     execjs (2.10.0)
     fast_blank (1.0.1)
     fastimage (2.4.0)
-    ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
-    google-protobuf (4.30.2-aarch64-linux)
+    google-protobuf (4.31.1-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.30.2-arm64-darwin)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.30.2-x86_64-linux)
-      bigdecimal
-      rake (>= 13)
-    govuk_tech_docs (4.3.1)
+    govuk_tech_docs (5.0.2)
       autoprefixer-rails (~> 10.2)
       base64
       bigdecimal
@@ -89,9 +81,7 @@ GEM
       concurrent-ruby (~> 1.0)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
-    libv8-node (18.16.0.0-aarch64-linux)
     libv8-node (18.16.0.0-arm64-darwin)
-    libv8-node (18.16.0.0-x86_64-linux)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -155,11 +145,7 @@ GEM
     minitest (5.25.5)
     multi_json (1.15.0)
     mutex_m (0.3.0)
-    nokogiri (1.18.8-aarch64-linux-gnu)
-      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
@@ -172,10 +158,10 @@ GEM
     parslet (2.0.0)
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (2.2.14)
+    rack (2.2.17)
     rack-livereload (0.3.17)
       rack
-    rake (13.2.1)
+    rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -183,12 +169,8 @@ GEM
     rexml (3.4.1)
     rouge (3.30.0)
     sass (3.4.25)
-    sass-embedded (1.87.0-aarch64-linux-gnu)
-      google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-arm64-darwin)
-      google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-x86_64-linux-gnu)
-      google-protobuf (~> 4.30)
+    sass-embedded (1.89.2-arm64-darwin)
+      google-protobuf (~> 4.31)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-embedded (1.78.0)
@@ -199,7 +181,7 @@ GEM
       logger
       rack (>= 2.2.4, < 4)
     temple (0.10.3)
-    terser (1.2.5)
+    terser (1.2.6)
       execjs (>= 0.3.0, < 3)
     thor (1.2.2)
     tilt (2.0.11)
@@ -212,12 +194,10 @@ GEM
     webrick (1.9.1)
 
 PLATFORMS
-  aarch64-linux
   arm64-darwin-23
-  x86_64-linux
 
 DEPENDENCIES
-  govuk_tech_docs (~> 4.3.1)
+  govuk_tech_docs (~> 5.0.2)
   mini_racer (~> 0.8.0)
 
 BUNDLED WITH


### PR DESCRIPTION
Release v5.0.2 - https://github.com/alphagov/tech-docs-gem/releases/tag/v5.0.2 - enables rebrand for a site that uses the crown

Trello ticket: https://trello.com/c/eIepj4vM/1346-turn-on-new-govuk-brand-in-our-web-apps-and-the-email-template

<img width="993" alt="Screenshot 2025-06-17 at 15 29 17" src="https://github.com/user-attachments/assets/f2fbeb45-8db4-440c-8b47-154baa7fc281" />
