### PR TITLE
Add economy mail

### DIFF
--- a/source/java.html.md.erb
+++ b/source/java.html.md.erb
@@ -652,7 +652,7 @@ InputStream precompiledPDFAsInputStream = new FileInputStream(pdfContent);
 
 ##### postage (optional)
 
-You can choose first class, second class or economy mail postage for your precompiled letter. Set the value to first for first class, or second for second class. If you do not pass in this argument, the postage will default to second class.
+You can choose first class, second class or economy mail postage for your precompiled letter. Set the value to `first` for first class, `second` for second class or `economy` for economy mail. If you do not pass in this argument, the postage will default to second class.
 
 #### Response
 

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -690,7 +690,7 @@ The precompiled letter must be a PDF file which meets [the GOV.UK Notify letter 
 
 ##### postage (optional)
 
-You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
+You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, `second` for second class or `economy` for economy mail. If you do not pass in this argument, the postage will default to second class.
 
 ```javascript
 "postage": "second"

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -690,7 +690,7 @@ The precompiled letter must be a PDF file which meets [the GOV.UK Notify letter 
 
 ##### postage (optional)
 
-You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, `second` for second class or `economy` for economy mail. If you do not pass in this argument, the postage will default to second class.
+You can choose first class, second class or economy mail postage for your precompiled letter. Set the value to `first` for first class, `second` for second class or `economy` for economy mail. If you do not pass in this argument, the postage will default to second class.
 
 ```javascript
 "postage": "second"


### PR DESCRIPTION
We missed economy mail from:

* the REST API documentation
* the Java client documentation

This PR adds that content in the same format is it appears in the other API client docs.