### PR TITLE
Add schema validation errors sub-section to all the tech docs

### DIFF
--- a/source/documentation/error_tables/_generate_a_preview_template.md
+++ b/source/documentation/error_tables/_generate_a_preview_template.md
@@ -5,5 +5,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to generating a preview template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_generic_errors.md
+++ b/source/documentation/error_tables/_generic_errors.md
@@ -32,7 +32,7 @@ Error message | How to fix
 `sms_sender_id is not a valid UUID`|Check the argument to make sure that it is valid for the given data type.|
 `personalisation <data type of argument you sent> is not of type object`|Provide argument in the correct type.|
 `reference <reference string you provided> is too long`|Provide a shorter string.|
-`template_type <invalid type> is not one of [sms, email, letter]`|Make sure that the argument matches one of the items in the list.|
+`type <invalid type> is not one of [sms, email, letter]`|Make sure that the argument matches one of the items in the list.|
 `Additional properties are not allowed (<list of unexpected properties> was unexpected)`|Only provide allowed arguments for the endpoint.|
 
 

--- a/source/documentation/error_tables/_generic_errors.md
+++ b/source/documentation/error_tables/_generic_errors.md
@@ -21,11 +21,24 @@ Error message | How to fix
 **Exception (status code 500)**|
 `Internal server error`|Notify was unable to process the request, resend your notification.|
 
-In addition to the above, you may also encounter:
+### Schema validation errors
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+The following are a few examples of schema validation errors you may encounter when making a request to a Notify endpoint.
 
-* endpoint-specific errors, which are listed under each relevant API endpoint section.
+Error message | How to fix
+---|---
+**ValidationError (status code 400)**|
+`template_id is a required property`|Provide the missing argument.|
+`sms_sender_id is not a valid UUID`|Check the argument to make sure that it is valid for the given data type.|
+`personalisation <data type of argument you sent> is not of type object`|Provide argument in the correct type.|
+`reference <reference string you provided> is too long`|Provide a shorter string.|
+`template_type <invalid type> is not one of [sms, email, letter]`|Make sure that the argument matches one of the items in the list.|
+`Additional properties are not allowed (<list of unexpected properties> was unexpected)`|Only provide allowed arguments for the endpoint.|
+
+
+### Endpoint-specific errors
+
+In addition to the above, you may also encounter endpoint-specific errors, which are listed under each relevant API endpoint section.
 
 Find references for endpoint-specific errors in:
 

--- a/source/documentation/error_tables/_get_a_page_of_received_text_messages.md
+++ b/source/documentation/error_tables/_get_a_page_of_received_text_messages.md
@@ -1,4 +1,4 @@
 There are no errors specific to this endpoint, but you may encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to generating a preview template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_get_a_pdf_for_a_letter_notification.md
+++ b/source/documentation/error_tables/_get_a_pdf_for_a_letter_notification.md
@@ -12,5 +12,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting a PDF for a letter, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_get_a_template_by_id.md
+++ b/source/documentation/error_tables/_get_a_template_by_id.md
@@ -3,5 +3,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting a template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_get_a_template_by_id_and_version.md
+++ b/source/documentation/error_tables/_get_a_template_by_id_and_version.md
@@ -3,5 +3,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting a template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_get_the_status_of_multiple_messages.md
+++ b/source/documentation/error_tables/_get_the_status_of_multiple_messages.md
@@ -4,5 +4,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting the status of messages, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_get_the_status_of_one_message.md
+++ b/source/documentation/error_tables/_get_the_status_of_one_message.md
@@ -5,5 +5,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting the status of a message, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_send_a_file_by_email.md
+++ b/source/documentation/error_tables/_send_a_file_by_email.md
@@ -13,5 +13,5 @@
 In addition to the above, you may also encounter:
 
 * other errors related to [sending an email](#send-an-email).
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending an email, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_send_a_letter.md
+++ b/source/documentation/error_tables/_send_a_letter.md
@@ -17,5 +17,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending an email, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_send_a_precompiled_letter.md
+++ b/source/documentation/error_tables/_send_a_precompiled_letter.md
@@ -10,5 +10,5 @@
 In addition to the above, you may also encounter:
 
 * other errors related to [sending an letter](#send-a-letter).
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending a letter, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/_send_a_text_message.md
+++ b/source/documentation/error_tables/_send_a_text_message.md
@@ -11,5 +11,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending a text message, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors).

--- a/source/documentation/error_tables/_send_an_email.md
+++ b/source/documentation/error_tables/_send_an_email.md
@@ -8,6 +8,6 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors about a file you try to send via email. You can find a list of these errors at the end of [Send a file by email](#send-a-file-by-email)
 * errors that are not related to sending an email, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_generate_a_preview_template.md
+++ b/source/documentation/error_tables/ruby/_generate_a_preview_template.md
@@ -5,5 +5,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to generating a preview template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_generic_errors.md
+++ b/source/documentation/error_tables/ruby/_generic_errors.md
@@ -20,11 +20,24 @@ Error message | How to fix
 **ServerError (status code 500)**|
 `Exception: Internal server error`|Notify was unable to process the request, resend your notification.|
 
-In addition to the above, you may also encounter:
+### Schema validation errors
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+The following are a few examples of schema validation errors you may encounter when making a request to a Notify endpoint.
 
-* endpoint-specific errors, which are listed under each relevant API endpoint section.
+Error message | How to fix
+---|---
+**BadRequestError (status code 400)**|
+`ValidationError: template_id is a required property`|Provide the missing argument.|
+`ValidationError: sms_sender_id is not a valid UUID`|Check the argument to make sure that it is valid for the given data type.|
+`ValidationError: personalisation <data type of argument you sent> is not of type object`|Provide argument in the correct type.|
+`ValidationError: reference <reference string you provided> is too long`|Provide a shorter string.|
+`ValidationError: template_type <invalid type> is not one of [sms, email, letter]`|Make sure that the argument matches one of the items in the list.|
+`ValidationError: Additional properties are not allowed (<list of unexpected properties> was unexpected)`|Only provide allowed arguments for the endpoint.|
+
+
+### Endpoint-specific errors
+
+In addition to the above, you may also encounter endpoint-specific errors, which are listed under each relevant API endpoint section.
 
 Find references for endpoint-specific errors in:
 

--- a/source/documentation/error_tables/ruby/_get_a_page_of_received_text_messages.md
+++ b/source/documentation/error_tables/ruby/_get_a_page_of_received_text_messages.md
@@ -1,4 +1,4 @@
 There are no errors specific to this endpoint, but you may encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to generating a preview template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_get_a_pdf_for_a_letter_notification.md
+++ b/source/documentation/error_tables/ruby/_get_a_pdf_for_a_letter_notification.md
@@ -10,5 +10,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting a PDF for a letter, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_get_a_template_by_id.md
+++ b/source/documentation/error_tables/ruby/_get_a_template_by_id.md
@@ -3,5 +3,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting a template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_get_a_template_by_id_and_version.md
+++ b/source/documentation/error_tables/ruby/_get_a_template_by_id_and_version.md
@@ -3,5 +3,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting a template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_get_all_templates.md
+++ b/source/documentation/error_tables/ruby/_get_all_templates.md
@@ -3,5 +3,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting a template, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_get_the_status_of_multiple_messages.md
+++ b/source/documentation/error_tables/ruby/_get_the_status_of_multiple_messages.md
@@ -4,5 +4,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting the status of messages, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_get_the_status_of_one_message.md
+++ b/source/documentation/error_tables/ruby/_get_the_status_of_one_message.md
@@ -5,5 +5,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to getting the status of a message, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_send_a_file_by_email.md
+++ b/source/documentation/error_tables/ruby/_send_a_file_by_email.md
@@ -13,5 +13,5 @@
 In addition to the above, you may also encounter:
 
 * other errors related to [sending an email](#send-an-email).
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending an email, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_send_a_letter.md
+++ b/source/documentation/error_tables/ruby/_send_a_letter.md
@@ -16,5 +16,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending an email, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_send_a_precompiled_letter.md
+++ b/source/documentation/error_tables/ruby/_send_a_precompiled_letter.md
@@ -9,5 +9,5 @@
 In addition to the above, you may also encounter:
 
 * other errors related to [sending an letter](#send-a-letter).
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending a letter, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)

--- a/source/documentation/error_tables/ruby/_send_a_text_message.md
+++ b/source/documentation/error_tables/ruby/_send_a_text_message.md
@@ -10,5 +10,5 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors that are not related to sending a text message, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors).

--- a/source/documentation/error_tables/ruby/_send_an_email.md
+++ b/source/documentation/error_tables/ruby/_send_an_email.md
@@ -7,6 +7,6 @@
 
 In addition to the above, you may also encounter:
 
-* various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type.
+* [various schema validation errors](#schema-validation-errors), for example when you forget to pass in an argument, or pass in an argument of a wrong type.
 * errors about a file you try to send via email. You can find a list of these errors at the end of [Send a file by email](#send-a-file-by-email)
 * errors that are not related to sending an email, but instead are related to things like authentication and rate limits. You can find a list of these errors [in General errors](#general-errors)


### PR DESCRIPTION
## What it is

Add schema validation errors sub-section to all the tech docs to show service users example schema validation errors they may see when interacting with our API.

Also link from all error sections that mention schema validation errors to this new schema validation errors sub-section.

## How to review

1. Look the code over - easier when done commit by commit.
2. Run the app locally and check if everything looks as expected.

## Screenshots:

### Regular docs:
![Screenshot 2025-07-09 at 17 25 19](https://github.com/user-attachments/assets/fc8a33d4-ce0b-49b8-a454-242dc339d887)

### Ruby docs:
![Screenshot 2025-07-09 at 17 28 41](https://github.com/user-attachments/assets/86fd9afd-1dea-4460-af38-c1744b6a32b3)

### An example link to schema validation errors sub-section:
![Screenshot 2025-07-09 at 17 42 30](https://github.com/user-attachments/assets/faaee73c-c2b8-4e57-9e0f-bcd042b845f7)
