### PR TITLE
Change headers and content to talk about message data instead of statuses

### DIFF
--- a/openapi/GET_PDF_For_Letter.json
+++ b/openapi/GET_PDF_For_Letter.json
@@ -64,7 +64,7 @@
         ],
         "summary": "Get the the PDF contents of a letter",
         "tags": [
-            "Get message status"
+            "Get message data"
         ]
     }
 }

--- a/openapi/GET_received_text_messages.json
+++ b/openapi/GET_received_text_messages.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "description": "**Get received text messages**\nThis API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.\nYou can only get the status of messages that are 7 days old or newer.\n**Enable received text messages**\nTo receive text messages:\n1.  Go to the **Text message settings** section of the **Settings** page.\n2.  Select **Change** on the **Receive text messages** row.",
+        "description": "**Get received text messages**\nThis API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.\nYou can only get the data for messages that are 7 days old or newer.\n**Enable received text messages**\nTo receive text messages:\n1.  Go to the **Text message settings** section of the **Settings** page.\n2.  Select **Change** on the **Receive text messages** row.",
         "operationId": "getReceivedMessagesStatus",
         "parameters": [
             {

--- a/openapi/GET_status_message.json
+++ b/openapi/GET_status_message.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "description": "You can use this endpoint to get status of one message. Message status depends on the type of message you have sent.<br />You can only get the status of messages sent within the retention period. The default retention period is 7 days.<br />You can omit any of these optional arguments to ignore these filters.",
+        "description": "You can use this endpoint to get status of one message. Message status depends on the type of message you have sent.<br />You can only get the data for messages sent within the retention period. The default retention period is 7 days.<br />You can omit any of these optional arguments to ignore these filters.",
         "operationId": "getMessageStatus",
         "parameters": [
             {
@@ -61,9 +61,9 @@
                 "BearerAuth": []
             }
         ],
-        "summary": "Get the status of one message",
+        "summary": "Get the data for one message",
         "tags": [
-            "Get message status"
+            "Get message data"
         ]
     }
 }

--- a/openapi/GET_status_messages.json
+++ b/openapi/GET_status_messages.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "description": "This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.<br />You can only get the status of messages that are 7 days old or newer.<br />This will return all your messages with statuses. They will display in pages of up to 250 messages each.<br />You can omit any of these arguments to ignore these filters.",
+        "description": "This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.<br />You can only get the data for messages that are 7 days old or newer.<br />This will return all your messages with statuses. They will display in pages of up to 250 messages each.<br />You can omit any of these arguments to ignore these filters.",
         "operationId": "getMultipleMessagesStatus",
         "parameters": [
             {
@@ -133,9 +133,9 @@
                 "BearerAuth": []
             }
         ],
-        "summary": "Get the status of multiple messages",
+        "summary": "Get the data for multiple messages",
         "tags": [
-            "Get message status"
+            "Get message data"
         ]
     }
 }

--- a/openapi/make_request.json
+++ b/openapi/make_request.json
@@ -3,6 +3,6 @@
     "operationId": "getLetterPdfContents",
     "summary": "Get the the PDF contents of a letter",
     "tags": [
-        "Get message status"
+        "Get message data"
     ]
 }

--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -24,8 +24,8 @@
             "description": "Send a message."
         },
         {
-            "name": "Get message status",
-            "description": "Get message status"
+            "name": "Get message data",
+            "description": "Get message data"
         },
         {
             "name": "Get a template",

--- a/source/documentation/_error_messages.md
+++ b/source/documentation/_error_messages.md
@@ -13,6 +13,6 @@ Use the status_code or the error instead, as these will not change.
 Find error codes in:
 
 - [send a message](#send-a-message)
-- [get message status](#get-message-status)
+- [get message data](#get-message-data)
 - [get a template](#get-a-template)
 - [get received text messages](#get-received-text-messages)

--- a/source/documentation/_testing.md
+++ b/source/documentation/_testing.md
@@ -24,7 +24,7 @@ You can use these smoke test numbers and addresses with any [type of API key](#a
 
 You can smoke test all Notify API client functions except:
 
-- Get the status of one message
+- Get the data for one message
 - Get the status of all messages
 
 You cannot use the smoke test phone numbers or email address with these functions because they return a fake `notification_ID`. If you need to test these functions, use a test API key and any other phone number or email.

--- a/source/documentation/error_tables/_generic_errors.md
+++ b/source/documentation/error_tables/_generic_errors.md
@@ -43,6 +43,6 @@ In addition to the above, you may also encounter endpoint-specific errors, which
 Find references for endpoint-specific errors in:
 
 - [send a message](#send-a-message)
-- [get message status](#get-message-status)
+- [get message data](#get-message-data)
 - [get a template](#get-a-template)
 - [get received text messages](#get-received-text-messages)

--- a/source/documentation/error_tables/ruby/_generic_errors.md
+++ b/source/documentation/error_tables/ruby/_generic_errors.md
@@ -42,6 +42,6 @@ In addition to the above, you may also encounter endpoint-specific errors, which
 Find references for endpoint-specific errors in:
 
 - [send a message](#send-a-message)
-- [get message status](#get-message-status)
+- [get message data](#get-message-data)
 - [get a template](#get-a-template)
 - [get received text messages](#get-received-text-messages)

--- a/source/java.html.md.erb
+++ b/source/java.html.md.erb
@@ -673,12 +673,12 @@ If the request is not successful, the client returns an error. To learn more abo
 <%= partial 'documentation/error_tables/send_a_precompiled_letter' %>
 
 
-## Get message status
+## Get message data
 
 
-### Get the status of one message
+### Get the data for one message
 
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days.
 
 #### Method
 
@@ -742,9 +742,9 @@ If the request is not successful, the client returns an error. To learn more abo
 <%= partial 'documentation/error_tables/get_the_status_of_one_message' %>
 
 
-### Get the status of multiple messages
+### Get the data for multiple messages
 
-This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThanId`](#olderthanid-optional) argument.
+This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThanId`](#olderthanid-optional) argument.
 
 You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 

--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -743,10 +743,10 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |:---|:---|
 <%= partial 'documentation/error_tables/send_a_precompiled_letter' %>
 
-## Get message status
-### Get the status of one message
+## Get message data
+### Get the data for one message
 
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days.
 
 #### Method
 
@@ -837,7 +837,7 @@ Error message|How to fix|
 <%= partial 'documentation/error_tables/get_the_status_of_one_message' %>
 
 
-### Get the status of multiple messages
+### Get the data for multiple messages
 
 This API call returns the status of multiple messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `olderThanId` argument.
 
@@ -1224,7 +1224,7 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `olderThanId` argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get the data for messages that are 7 days old or newer.
 
 You can also set up [callbacks](#callbacks) for received text messages.
 

--- a/source/node.html.md.erb
+++ b/source/node.html.md.erb
@@ -760,12 +760,12 @@ If the request is not successful, the promise fails with an `err`. To learn more
 <%= partial 'documentation/error_tables/send_a_precompiled_letter' %>
 
 
-## Get message status
+## Get message data
 
 
-### Get the status of one message
+### Get the data for one message
 
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days.
 
 #### Method
 
@@ -845,9 +845,9 @@ Error message|How to fix|
 <%= partial 'documentation/error_tables/get_the_status_of_one_message' %>
 
 
-### Get the status of multiple messages
+### Get the data for multiple messages
 
-This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThan`](#olderthan-optional) argument.
+This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThan`](#olderthan-optional) argument.
 
 You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 

--- a/source/php.html.md.erb
+++ b/source/php.html.md.erb
@@ -714,12 +714,12 @@ If the request is not successful, the client returns an error. To learn more abo
 |:---|:---|
 <%= partial 'documentation/error_tables/send_a_precompiled_letter' %>
 
-## Get message status
+## Get message data
 
 
-### Get the status of one message
+### Get the data for one message
 
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days.
 
 #### Method
 
@@ -804,9 +804,9 @@ If the request is not successful, the client returns an error. To learn more abo
 <%= partial 'documentation/error_tables/get_the_status_of_one_message' %>
 
 
-### Get the status of multiple messages
+### Get the data for multiple messages
 
-This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
+This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
 You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
@@ -1222,7 +1222,7 @@ If the request is not successful, the client returns an error. To learn more abo
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get the data for messages that are 7 days old or newer.
 
 You can also set up [callbacks](#callbacks) for received text messages.
 

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -885,9 +885,9 @@ If you leave out this argument, the method only returns notifications sent using
 
 #### Response
 
-If the request to the client is successful, the client returns a `dict`.
+##### One page of up to 250 messages
 
-##### All messages
+If the request to the client is successful, the client returns a `dict`.
 
 ```python
 {
@@ -943,7 +943,9 @@ If the request to the client is successful, the client returns a `dict`.
 }
 ```
 
-##### One page of up to 250 messages
+##### All messages
+
+If the request to the client is successful, the client returns an iterator object which yields one notification at a time until it has yielded all your notifications. Each notification is a dict.
 
 ```python
 <generator object NotificationsAPIClient.get_all_notifications_iterator at 0x1026c7410>

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -683,11 +683,11 @@ If the request is not successful, the client returns an error. To learn more abo
 <%= partial 'documentation/error_tables/send_a_precompiled_letter' %>
 
 
-## Get message status
+## Get message data
 
-### Get the status of one message
+### Get the data for one message
 
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days.
 
 #### Method
 
@@ -774,19 +774,16 @@ If the request is not successful, the client returns an error. To learn more abo
 <%= partial 'documentation/error_tables/get_the_status_of_one_message' %>
 
 
-### Get the status of multiple messages
+### Get the data for multiple messages
 
-This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
-
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days. It can be changed in your Service Settings.
 
 #### Method
 
 ##### One page of up to 250 messages
 
-This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
+This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
-You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
 ```python
 response = notifications_client.get_all_notifications(
@@ -1286,7 +1283,7 @@ If the request is not successful, the client returns an error. To learn more abo
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get the data for messages that are 7 days old or newer.
 
 ### Enable received text messages
 

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -719,11 +719,11 @@ If the request is not successful, the API returns `json` containing the relevant
 
 
 
-## Get message status
+## Get message data
 
-### Get the status of one message
+### Get the data for one message
 
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days.
 
 #### Method
 
@@ -800,9 +800,9 @@ If the request is not successful, the API returns `json` containing the relevant
 <%= partial 'documentation/error_tables/get_the_status_of_one_message' %>
 
 
-### Get the status of multiple messages
+### Get the data for multiple messages
 
-This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
+This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
 You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
@@ -1274,7 +1274,7 @@ If the request is not successful, the API returns `json` containing the relevant
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the older_than query parameter.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get the data for messages that are 7 days old or newer.
 
 ### Enable received text messages
 

--- a/source/ruby.html.md.erb
+++ b/source/ruby.html.md.erb
@@ -643,13 +643,13 @@ If the request is not successful, the client returns an error. To learn more abo
 |:---|:---|
 <%= partial 'documentation/error_tables/ruby/send_a_precompiled_letter' %>
 
-## Get message status
+## Get message data
 
 
 
-### Get the status of one message
+### Get the data for one message
 
-You can only get the status of messages sent within the retention period. The default retention period is 7 days.
+You can only get the data for messages sent within the retention period. The default retention period is 7 days.
 
 #### Method
 
@@ -711,9 +711,9 @@ If the request is not successful, the client returns an error. To learn more abo
 |:---|:---|
 <%= partial 'documentation/error_tables/ruby/get_the_status_of_one_message' %>
 
-### Get the status of multiple messages
+### Get the data for multiple messages
 
-This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
+This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
 You can only get messages that are within your data retention period. The default data retention period is 7 days. It can be changed in your Service Settings.
 
@@ -1135,7 +1135,7 @@ If the request is not successful, the client returns an error. To learn more abo
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
-You can only get the status of messages that are 7 days old or newer.
+You can only get the data for messages that are 7 days old or newer.
 
 You can also set up [callbacks](#callbacks) for received text messages.
 


### PR DESCRIPTION
The headers were misleading, and lead to some of our own developers to think that these endpoints just provide message status, whereas they provide comprehensive data about the messages.

The content was preliminarily consulted with @karlchillmaid.

<img width="801" height="802" alt="Screenshot 2025-07-23 at 17 24 29" src="https://github.com/user-attachments/assets/e3eadade-134b-4af8-828f-82eda2e9197a" />
