### PR TITLE
Remove references to broadcasts

### DIFF
--- a/openapi/GET_templates.json
+++ b/openapi/GET_templates.json
@@ -155,7 +155,7 @@
                                     "errors":
                                     [{
                                         "error":"ValidationError",
-                                        "message":"type pigeon is not one of [sms, email, letter, broadcast]"
+                                        "message":"type pigeon is not one of [sms, email, letter]"
                                     }],
                                     "status_code": 400
                         }

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -1086,7 +1086,7 @@
                                 },
                                 "message": {
                                     "type": "string",
-                                    "example": "type pigeon is not one of [sms, email, letter, broadcast]",
+                                    "example": "type pigeon is not one of [sms, email, letter]",
                                     "description": "Error message"
                                 }
                             }


### PR DESCRIPTION
The openapi docs are the only ones which reference broadcasts in the validation error messages. The error message can change to be like that of the clients and REST API docs, since "broadcast" will not be returned as part of the error from the API.