### PR TITLE
Update OpenAPI spec with endpoint specific errors to be consistent with REST doc

### DIFF
--- a/openapi/GET_PDF_For_Letter.json
+++ b/openapi/GET_PDF_For_Letter.json
@@ -5,7 +5,7 @@
         "parameters": [
             {
                 "description": "The ID of the notification. You can find the notification ID in the response to the original notification method call.\nYou can also find it by [signing in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and going to the **API integration** page.",
-                "example": "740e5834-3a29-46b4-9a6f-16142fde533a",
+                "example": "3d1ce039-5476-414c-99b2-fac1e6add62c",
                 "in": "path",
                 "name": "notification_id",
                 "schema": {
@@ -24,17 +24,64 @@
                         }
                     }
                 },
-                "description": "If the request to the client is successful, the client will return bytes representing the raw PDF data."
+                "description": "If the request to the API is successful, the API will return bytes representing the raw PDF data"
             },
             "400": {
                 "content": {
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/GetMessageValidationError"
+                        },
+                        "examples": {
+                            "ID is not a valid ID": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "id is not a valid UUID"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "PDF not available yet": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "PDFNotReadyError",
+                                        "message": "PDF not available yet, try again later"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "File did not pass the virus scan": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "File did not pass the virus scan"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "PDF not available for letters": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "PDF not available for letters in technical-failure"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Notification is not a letter": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Notification is not a letter"
+                                    }],
+                                    "status_code": 400
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed.  In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {

--- a/openapi/GET_data_for_message.json
+++ b/openapi/GET_data_for_message.json
@@ -30,10 +30,21 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/GetMessageValidationError"
+                        },
+                        "examples": {
+                            "Not a valid email address": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "id is not a valid UUID"
+                                    }],
+                                    "status_code": 400
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -50,10 +61,21 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/GetMessageNoResultFoundError"
+                        },
+                        "examples": {
+                            "Not a valid email address": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "NoResultFound",
+                                        "message": "No result found"
+                                    }],
+                                    "status_code": 404
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Result not found. Check the `message` in the response to find out why your request failed."
+                "description": "Result not found. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "security": [

--- a/openapi/GET_data_for_messages.json
+++ b/openapi/GET_data_for_messages.json
@@ -4,7 +4,7 @@
         "operationId": "getMultipleMessagesStatus",
         "parameters": [
             {
-                "description": "You can filter by `email`, `sms` or `letter`",
+                "description": "Filter by `email`, `sms` or `letter`",
                 "in": "query",
                 "name": "template_type",
                 "schema": {
@@ -14,10 +14,11 @@
                         "sms",
                         "letter"
                     ]
-                }
+                },
+                "example": "email"
             },
             {
-                "description": "You can filter by message status.",
+                "description": "Filter by message status. See list for each notification type at https://docs.notifications.service.gov.uk/rest-api.html#email-status-descriptions .<br /><br />You can leave out this argument to ignore this filter.<br /><br />You can filter on multiple statuses by repeating the query string.",
                 "in": "query",
                 "name": "status",
                 "schema": {
@@ -59,17 +60,16 @@
                 }
             },
             {
-                "description": "An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address.",
+                "description": "This reference identifies a single notification or a batch of notifications and was defined when the notification was sent. <br /><br />You can filter on multiple statuses by repeating the query string.<br /><br />You can leave out this argument to ignore this filter.",
                 "name": "reference",
                 "in": "query",
                 "schema": {
                     "type": "string"
                 },
-                "example": "STRING"
+                "example": "your%20reference"
             },
             {
-                "description": "Input the ID of a notification into this argument. If you use this argument, the method returns the next 250 received notifications older than the given ID.<br />If you leave out this argument, the method returns the most recent 250 notifications.<br />The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty response.",
-                "name": "older_than",
+                "description": "Input a notification ID into this argument. If you use this argument, the method returns the next 250 messages older than the given ID.<br /><br />If you leave out this argument, the method returns the most recent 250 messages.<br /><br />The API only returns messages sent within the retention period. The default retention period is 7 days. If the message specified in this argument was sent before the retention period, the API returns an empty response.",
                 "in": "query",
                 "schema": {
                     "type": "string"
@@ -77,7 +77,7 @@
                 "example": "740e5834-3a29-46b4-9a6f-16142fde533a"
             },
             {
-                "description": "Includes notifications sent as part of a batch upload.<br />If you leave out this argument, the method only returns notifications sent using the API.",
+                "description": "Include notifications sent as part of a batch upload.<br /><br />If you leave out this argument, the method only returns notifications sent using the API.",
                 "name": "include_jobs",
                 "in": "query",
                 "schema": {

--- a/openapi/GET_data_for_messages.json
+++ b/openapi/GET_data_for_messages.json
@@ -1,6 +1,6 @@
 {
     "get": {
-        "description": "This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.<br />You can only get the data for messages that are 7 days old or newer.<br />This will return all your messages with statuses. They will display in pages of up to 250 messages each.<br />You can omit any of these arguments to ignore these filters.",
+        "description": "This API call returns one page with data for up to 250 messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.<br /><br />You can only get the data for messages that are 7 days old or newer.<br /><br />This will return all your messages with statuses. They will display in pages of up to 250 messages each.<br />You can omit any of these arguments to ignore these filters.",
         "operationId": "getMultipleMessagesStatus",
         "parameters": [
             {
@@ -40,24 +40,7 @@
                         "technical-failure"
                     ]
                 },
-                "examples": {
-                    "Emails": {
-                        "summary": "Emails Status",
-                        "description": "| Status | Description |\n| --- | --- |\n| `created` | GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds. |\n| `sending` | GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information. |\n| `delivered` | The message was successfully delivered. |\n| `permanent-failure` | The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database. |\n| `temporary-failure` | The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again. |\n| `technical-failure` | Your message was not sent because there was a problem between Notify and the provider.  <br>You’ll have to try sending your messages again. |\n"
-                    },
-                    "Text Message": {
-                        "summary": "Text Message Status",
-                        "description": "| Status | Description |\n| --- | --- |\n| `created` | GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds. |\n| `sending` | GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information. |\n| `pending` | GOV.UK Notify is waiting for more delivery information.  <br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message. |\n| `sent` | The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as ‘Sent to an international number’. |\n| `delivered` | The message was successfully delivered. If a recipient blocks your sender ID or mobile number, your message will still show as delivered. |\n| `permanent-failure` | The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered. |\n| `temporary-failure` | The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages. |\n| `technical-failure` | Your message was not sent because there was a problem between Notify and the provider.  <br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure. |"
-                    },
-                    "Letter": {
-                        "summary": "Letter Status",
-                        "description": "| Status | Description |\n| --- | --- |\n| `accepted` | GOV.UK Notify has sent the letter to the provider to be printed. |\n| `received` | The provider has printed and dispatched the letter. |\n| `cancelled` | Sending cancelled. The letter will not be printed or dispatched. |\n| `technical-failure` | GOV.UK Notify had an unexpected error while sending the letter to our printing provider. |\n| `permanent-failure` | The provider cannot print the letter. Your letter will not be dispatched. |"
-                    },
-                    "Precompiled Letter": {
-                        "summary": "Precompiled Letter Status",
-                        "description": "| Status | Description |\n| --- | --- |\n| `accepted` | GOV.UK Notify has sent the letter to the provider to be printed. |\n| `received` | The provider has printed and dispatched the letter. |\n| `cancelled` | Sending cancelled. The letter will not be printed or dispatched. |\n| `pending-virus-check` | GOV.UK Notify has not completed a virus scan of the precompiled letter file. |\n| `virus-scan-failed` | GOV.UK Notify found a potential virus in the precompiled letter file. |\n| `validation-failed` | Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information. |\n| `technical-failure` | GOV.UK Notify had an unexpected error while sending the letter to our printing provider. |\n| `permanent-failure` | The provider cannot print the letter. Your letter will not be dispatched. |"
-                    }
-                }
+                "example": "sending"
             },
             {
                 "description": "This reference identifies a single notification or a batch of notifications and was defined when the notification was sent. <br /><br />You can filter on multiple statuses by repeating the query string.<br /><br />You can leave out this argument to ignore this filter.",
@@ -70,6 +53,7 @@
             },
             {
                 "description": "Input a notification ID into this argument. If you use this argument, the method returns the next 250 messages older than the given ID.<br /><br />If you leave out this argument, the method returns the most recent 250 messages.<br /><br />The API only returns messages sent within the retention period. The default retention period is 7 days. If the message specified in this argument was sent before the retention period, the API returns an empty response.",
+                "name": "older_than",
                 "in": "query",
                 "schema": {
                     "type": "string"
@@ -102,10 +86,30 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/GetMessageValidationError"
+                        },
+                        "examples": {
+                            "Invalid status": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "status 'elephant' is not one of [cancelled, created, sending, sent, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure, pending-virus-check, validation-failed, virus-scan-failed, returned-letter, accepted, received]"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Invalid template_type": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "'Apple' is not one of [sms, email, letter]"
+                                    }],
+                                    "status_code": 400
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {

--- a/openapi/GET_received_text_messages.json
+++ b/openapi/GET_received_text_messages.json
@@ -4,11 +4,13 @@
         "operationId": "getReceivedMessagesStatus",
         "parameters": [
             {
-                "description": "The ID of a received text message. If this is passed, the response will only list text messages received before that message.",
+                "description": "Input the ID of a received text message into this argument. If you use this argument, the method returns the next 250 received text messages older than the given ID.",
                 "in": "query",
                 "name": "older_than",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "740e5834-3a29-46b4-9a6f-16142fde533a",
+                    "description": "optional string - notification ID"
                 }
             }
         ],
@@ -31,7 +33,7 @@
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -41,7 +43,7 @@
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "404": {
                 "content": {
@@ -51,7 +53,7 @@
                         }
                     }
                 },
-                "description": "Result not found. Check the `message` in the response to find out why your request failed."
+                "description": "Result not found. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "security": [

--- a/openapi/GET_template_by_id.json
+++ b/openapi/GET_template_by_id.json
@@ -10,7 +10,7 @@
             "schema": {
                 "$ref": "schema.json#/components/schemas/TemplateByIdRequest"
             },
-            "example": "b7a59abd-0ab2-4538-b619-8da9f9089e08"      
+            "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"      
         }],
         "responses": {
             "200": {
@@ -18,20 +18,6 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/TemplateResponse"
-                        },
-                        "example": {
-                                "id":"b7a59abd-0ab2-4538-b619-8da9f9089e08",
-                                "name":"Test SMS Template",
-                                "type":"sms",
-                                "created_at":"2024-08-12T11:03:12.000000Z",
-                                "updated_at":"2024-08-12T11:03:34.994540Z",
-                                "version":2,
-                                "created_by":"someone@example.com",
-                                "body":"Hi ((firstname)), We have received your letter dated ((date)).  No further action is required.",
-                                "subject":null,
-                                "postage":null,
-                                "letter_contact_block":null,
-                                "personalisation":{"date": {"required": true},"firstname": {"required": true}}
                         }
                     }
                 },
@@ -53,7 +39,7 @@
                         }
                     }
                 },
-                "description": "Make sure that the provided type is one of: email, sms, letter"
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -63,7 +49,7 @@
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "404": {
                 "content": {
@@ -81,7 +67,7 @@
                         }
                     }
                 },
-                "description": "Check your template ID"
+                "description": "Check your template ID. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "429": {
                 "content": {
@@ -91,7 +77,7 @@
                         }
                     }
                 },
-                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed."
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "500": {
                 "content": {
@@ -101,7 +87,7 @@
                         }
                     }
                 },
-                "description": "Internal server error. Check the `message` in the response to find out why your request failed."
+                "description": "Internal server error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "security": [

--- a/openapi/GET_template_by_id_and_version.json
+++ b/openapi/GET_template_by_id_and_version.json
@@ -10,7 +10,7 @@
             "schema": {
                 "$ref": "schema.json#/components/schemas/TemplateByIdRequest"
             },
-            "example": "b7a59abd-0ab2-4538-b619-8da9f9089e08"  
+            "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"  
         },
         {
             "name": "version",
@@ -20,7 +20,7 @@
             "schema": {
                 "$ref": "schema.json#/components/schemas/TemplateByIdAndVersionRequest"
             },
-            "example": 1
+            "example": 3
         }],
         "responses": {
             "200": {
@@ -28,20 +28,6 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/TemplateResponse"
-                        },
-                        "example": {
-                                "id":"b7a59abd-0ab2-4538-b619-8da9f9089e08",
-                                "name":"Test SMS Template",
-                                "type":"sms",
-                                "created_at":"2024-08-12T11:03:12.000000Z",
-                                "updated_at":"2024-08-12T11:03:34.994540Z",
-                                "version":2,
-                                "created_by":"someone@example.com",
-                                "body":"Hi ((firstname)), We have received your letter dated ((date)).  No further action is required.",
-                                "subject":null,
-                                "postage":null,
-                                "letter_contact_block":null,
-                                "personalisation":{"date": {"required": true},"firstname": {"required": true}}
                         }
                     }
                 },
@@ -63,7 +49,7 @@
                         }
                     }
                 },
-                "description": "Make sure that the provided type is one of: email, sms, letter"
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -73,7 +59,7 @@
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "404": {
                 "content": {
@@ -91,7 +77,7 @@
                         }
                     }
                 },
-                "description": "Check your template ID and version"
+                "description": "Check your template ID. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "429": {
                 "content": {
@@ -101,7 +87,7 @@
                         }
                     }
                 },
-                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed."
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "500": {
                 "content": {
@@ -111,7 +97,7 @@
                         }
                     }
                 },
-                "description": "Internal server error. Check the `message` in the response to find out why your request failed."
+                "description": "Internal server error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "security": [

--- a/openapi/GET_templates.json
+++ b/openapi/GET_templates.json
@@ -40,14 +40,14 @@
                                 "value": {
                                     "templates":
                                     [{
-                                        "id":"b7a59abd-0ab2-4538-b619-8da9f9089e08",
-                                        "name":"Test SMS Template",
+                                        "id":"f33517ff-2a88-4f6e-b855-c550268ce08a",
+                                        "name":"Pigeon registration - appointment SMS",
                                         "type":"sms",
-                                        "created_at":"2024-08-12T11:03:12.000000Z",
-                                        "updated_at":"2024-08-12T11:03:34.994540Z",
-                                        "version":2,
-                                        "created_by":"someone@example.com",
-                                        "body":"Hi ((firstname)), We have received your letter dated ((date)).  No further action is required.",
+                                        "created_at":"2024-05-10 10:30:31.142535Z",
+                                        "updated_at":"2024-08-25 13:00:09.123234Z",
+                                        "version":3,
+                                        "created_by":"charlie.smith@pigeons.gov.uk",
+                                        "body":"Hi ((firstname)), your appointment is on ((date))",
                                         "subject":null,
                                         "postage":null,
                                         "letter_contact_block":null,
@@ -59,18 +59,18 @@
                                 "value": {
                                     "templates":
                                     [{
-                                        "id":"8604d595-c65e-4d80-ae33-34fd08c736a5",
-                                        "name":"Test Email Template",
+                                        "id":"9d751e0e-f929-4891-82a1-a3e1c3c18ee3a",
+                                        "name":"Pigeon registration - appointment email",
                                         "type":"email",
-                                        "created_at":"2024-08-12T10:40:20.000000Z",
-                                        "updated_at":"2024-08-12T10:45:47.890097Z",
-                                        "version":3,
-                                        "created_by":"someone@example.com",
-                                        "body":"Hi ((firstname)),\r\nWe have received your letter dated ((date)).\r\n No further action is required.",
-                                        "subject":"Test Email",
+                                        "created_at":"2024-05-10 10:30:31.142535Z",
+                                        "updated_at":null,
+                                        "version":1,
+                                        "created_by":"charlie.smith@pigeons.gov.uk",
+                                        "body":"Dear ((first_name))\r\n\r\nYour pigeon registration appointment is scheduled for ((appointment_date)).\r\n\r\nPlease bring:\r\n\n\n((required_documents))\r\n\r\nYours,\r\nPigeon Affairs Bureau",
+                                        "subject":"Your upcoming pigeon registration appointment",
                                         "letter_contact_block":null,
                                         "postage":null,
-                                        "personalisation":{"date": {"required": true},"firstname": {"required": true}}
+                                        "personalisation":{"appointment_date": {"required": true},"first_name": {"required": true},"required_documents": {"required": true}}
                                     }]
                                 }
                             },
@@ -78,18 +78,18 @@
                                 "value": {
                                     "templates":
                                     [{
-                                        "id":"142d3a1b-f6cb-4bbb-9732-e1d9f9f2fed4",
-                                        "name":"Test Letter Template",
+                                        "id":"64415853-cb86-4cc4-b597-2aaa94ef8c39",
+                                        "name":"Pigeon registration - appointment letter",
                                         "type":"letter",
                                         "postage": "second",
-                                        "created_at":"2024-08-20T19:50:43.000000Z",
-                                        "updated_at":"2024-08-20T19:51:51.980848Z",
-                                        "version":2,
-                                        "created_by":"someone@example.com",
-                                        "body":"Hi ((firstname)), We have received your letter dated ((date)).  No further action is required.",
-                                        "subject":"Test Letter",
-                                        "letter_contact_block":"From Address\nCity",
-                                        "personalisation":{"date": {"required": true},"firstname": {"required": true}}
+                                        "created_at":"2024-05-10 10:30:31.142535Z",
+                                        "updated_at":"2024-08-25 13:00:09.123234Z",
+                                        "version":3,
+                                        "created_by":"charlie.smith@pigeons.gov.uk",
+                                        "body":"Dear ((first_name))\r\n\r\nYour pigeon registration appointment is scheduled for ((appointment_date)).\r\n\r\nPlease bring:\r\n\n\n((required_documents))\r\n\r\nYours,\r\nPigeon Affairs Bureau",
+                                        "subject":"Your upcoming pigeon registration appointment",
+                                        "letter_contact_block":"Pigeons Affairs Bureau\n10 Whitechapel High Street\nLondon\nE1 8EF",
+                                        "personalisation":{"appointment_date": {"required": true},"first_name": {"required": true},"required_documents": {"required": true}}
                                     }]
                                 }
                             },
@@ -97,46 +97,46 @@
                                 "value": {
                                     "templates":
                                     [{
-                                        "id":"b7a59abd-0ab2-4538-b619-8da9f9089e08",
-                                        "name":"Test SMS Template",
+                                        "id":"f33517ff-2a88-4f6e-b855-c550268ce08a",
+                                        "name":"Pigeon registration - appointment SMS",
                                         "type":"sms",
-                                        "created_at":"2024-08-12T11:03:12.000000Z",
-                                        "updated_at":"2024-08-12T11:03:34.994540Z",
-                                        "version":2,
-                                        "created_by":"someone@example.com",
-                                        "body":"Hi ((firstname)), We have received your letter dated ((date)).  No further action is required.",
+                                        "created_at":"2024-05-10 10:30:31.142535Z",
+                                        "updated_at":"2024-08-25 13:00:09.123234Z",
+                                        "version":3,
+                                        "created_by":"charlie.smith@pigeons.gov.uk",
+                                        "body":"Hi ((firstname)), your appointment is on ((date))",
                                         "subject":null,
                                         "postage":null,
                                         "letter_contact_block":null,
                                         "personalisation":{"date": {"required": true},"firstname": {"required": true}}
                                     },
                                     {
-                                        "id":"8604d595-c65e-4d80-ae33-34fd08c736a5",
-                                        "name":"Test Email Template",
+                                        "id":"9d751e0e-f929-4891-82a1-a3e1c3c18ee3a",
+                                        "name":"Pigeon registration - appointment email",
                                         "type":"email",
-                                        "created_at":"2024-08-12T10:40:20.000000Z",
-                                        "updated_at":"2024-08-12T10:45:47.890097Z",
-                                        "version":3,
-                                        "created_by":"someone@example.com",
-                                        "body":"Hi ((firstname)),\r\nWe have received your letter dated ((date)).\r\n No further action is required.",
-                                        "subject":"Test Email",
-                                        "letter_contact_block":null,
+                                        "created_at":"2024-05-10 10:30:31.142535Z",
+                                        "updated_at":null,
+                                        "version":1,
+                                        "created_by":"charlie.smith@pigeons.gov.uk",
+                                        "body":"Dear ((first_name))\r\n\r\nYour pigeon registration appointment is scheduled for ((appointment_date)).\r\n\r\nPlease bring:\r\n\n\n((required_documents))\r\n\r\nYours,\r\nPigeon Affairs Bureau",
+                                        "subject":"Your upcoming pigeon registration appointment",
                                         "postage":null,
-                                        "personalisation":{"date": {"required": true},"firstname": {"required": true}}
+                                        "letter_contact_block":null,
+                                        "personalisation":{"appointment_date": {"required": true},"first_name": {"required": true},"required_documents": {"required": true}}
                                     },
                                     {
-                                        "id":"142d3a1b-f6cb-4bbb-9732-e1d9f9f2fed4",
-                                        "name":"Test Letter Template",
+                                        "id":"64415853-cb86-4cc4-b597-2aaa94ef8c39",
+                                        "name":"Pigeon registration - appointment letter",
                                         "type":"letter",
-                                        "postage": "second",
-                                        "created_at":"2024-08-20T19:50:43.000000Z",
-                                        "updated_at":"2024-08-20T19:51:51.980848Z",
-                                        "version":2,
-                                        "created_by":"someone@example.com",
-                                        "body":"Hi ((firstname)), We have received your letter dated ((date)).  No further action is required.",
-                                        "subject":"Test Letter",
-                                        "letter_contact_block":"From Address\nCity",
-                                        "personalisation":{"date": {"required": true},"firstname": {"required": true}}
+                                        "created_at":"2024-05-10 10:30:31.142535Z",
+                                        "updated_at":"2024-08-25 13:00:09.123234Z",
+                                        "version":3,
+                                        "created_by":"charlie.smith@pigeons.gov.uk",
+                                        "body":"Dear ((first_name))\r\n\r\nYour pigeon registration appointment is scheduled for ((appointment_date)).\r\n\r\nPlease bring:\r\n\n\n((required_documents))\r\n\r\nYours,\r\nPigeon Affairs Bureau",
+                                        "subject":"Your upcoming pigeon registration appointment",
+                                        "postage":"second",
+                                        "letter_contact_block":"Pigeons Affairs Bureau\n10 Whitechapel High Street\nLondon\nE1 8EF",
+                                        "personalisation":{"appointment_date": {"required": true},"first_name": {"required": true},"required_documents": {"required": true}}
                                     }]
                                 }
                             }
@@ -161,7 +161,7 @@
                         }
                     }
                 },
-                "description": "Make sure that the provided type is one of: email, sms, letter"
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -171,7 +171,7 @@
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "429": {
                 "content": {
@@ -181,7 +181,7 @@
                         }
                     }
                 },
-                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed."
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "500": {
                 "content": {
@@ -191,7 +191,7 @@
                         }
                     }
                 },
-                "description": "Internal server error. Check the `message` in the response to find out why your request failed."
+                "description": "Internal server error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "security": [

--- a/openapi/POST_notification_email.json
+++ b/openapi/POST_notification_email.json
@@ -139,7 +139,7 @@
                         },
                         "security": [
                             {
-                                "BearerAuth": []
+                                "BearerToken": []
                             }
                         ],
                         "summary": "Email callback"

--- a/openapi/POST_notification_email.json
+++ b/openapi/POST_notification_email.json
@@ -29,10 +29,57 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/SendNotificaitonRequestError"
+                        },
+                        "examples": {
+                            "Not a valid email address": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "email_address Not a valid email address"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Unsubscribe url invalid": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "one_click_unsubscribe_url is not a valid https url"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Email reply to id does not exist": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "email_reply_to_id <reply to id> does not exist in database for service id <service id>"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Email too large": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Emails cannot be longer than 2000000 bytes. Your message is <rendered template size in bytes> bytes"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Cannot sent to recipient in trial mode": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Cannot send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"
+                                    }],
+                                    "status_code": 400
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -42,7 +89,7 @@
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "429": {
                 "content": {
@@ -52,7 +99,7 @@
                         }
                     }
                 },
-                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed."
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "500": {
                 "content": {
@@ -62,7 +109,7 @@
                         }
                     }
                 },
-                "description": "Internal server error. Check the `message` in the response to find out why your request failed."
+                "description": "Internal server error. Check the `message` in the response to find out why your request failed For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "callbacks": {

--- a/openapi/POST_notification_email.json
+++ b/openapi/POST_notification_email.json
@@ -67,7 +67,7 @@
                                     "status_code": 400
                                 }
                             },
-                            "Cannot sent to recipient in trial mode": {
+                            "Cannot send to recipient in trial mode": {
                                 "value": {
                                     "errors": [{
                                         "error": "BadRequestError",

--- a/openapi/POST_notification_letter.json
+++ b/openapi/POST_notification_letter.json
@@ -245,7 +245,7 @@
                 "{$callback_url}": {
                     "post": {
                         "requestBody": {
-                            "description": "When a letter you sent is returned, Notify will send details of the returned letter to your callback URL.\n\nFind more [information about returned letters](https://www.notifications.service.gov.uk/using-notify/delivery-times#returned-mail). It can take a few weeks to receive information about a returned letter.\n\nThe callback message is formatted in JSON. The key, description and format of the callback message arguments will be:",
+                            "description": "When a letter you sent is returned, Notify will send details of the returned letter to your callback URL.\n\nFind more [information about returned letters](https://www.notifications.service.gov.uk/using-notify/delivery-times#returned-mail). It can take a few weeks to receive information about a returned letter.\n\n### Set up callbacks\n\nYou must provide:\n\n- a URL where Notify will post the callback to\n- a bearer token which Notify will put in the authorisation header of the requests\n\nTo do this:\n\n1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).\n1. Go to the __API integration__ page.\n1. Select __Callbacks__.\n\n### Retry callbacks\n\nIf Notify sends a `POST` request to your service, but the request fails then we will retry.\n\nWe will retry every 5 minutes, up to a maximum of 5 times.\n\n### Returned letters\n\nThe callback message is formatted in JSON. The key, description and format of the callback message arguments will be:",
                             "content": {
                                 "application/json": {
                                     "schema": {
@@ -267,7 +267,7 @@
                         },
                         "security": [
                             {
-                                "BearerAuth": []
+                                "BearerToken": []
                             }
                         ],
                         "summary": "Returned letter callback"

--- a/openapi/POST_notification_letter.json
+++ b/openapi/POST_notification_letter.json
@@ -231,6 +231,41 @@
                 "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
+        "callbacks": {
+            "returnedLetter": {
+                "{$callback_url}": {
+                    "post": {
+                        "requestBody": {
+                            "description": "When a letter you sent is returned, Notify will send details of the returned letter to your callback URL.\n\nFind more [information about returned letters](https://www.notifications.service.gov.uk/using-notify/delivery-times#returned-mail). It can take a few weeks to receive information about a returned letter.\n\nThe callback message is formatted in JSON. The key, description and format of the callback message arguments will be:",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "schema.json#/components/schemas/LetterCallbackRequest"
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {
+                            "2XX": {
+                                "description": "Success"
+                            },
+                            "4XX": {
+                                "description": "Failed"
+                            },
+                            "5XX": {
+                                "description": "Failed"
+                            }
+                        },
+                        "security": [
+                            {
+                                "BearerAuth": []
+                            }
+                        ],
+                        "summary": "Returned letter callback"
+                    }
+                }
+            }
+        },
         "security": [
             {
                 "BearerAuth": []

--- a/openapi/POST_notification_letter.json
+++ b/openapi/POST_notification_letter.json
@@ -193,6 +193,15 @@
                                     }],
                                     "status_code": 400
                                 }
+                            },
+                            "Letter content is not a valid PDF": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Letter content is not a valid PDF"
+                                    }],
+                                    "status_code": 400
+                                }
                             }
                         }
                     }

--- a/openapi/POST_notification_letter.json
+++ b/openapi/POST_notification_letter.json
@@ -11,30 +11,28 @@
                     "examples": {
                         "Letter": {
                             "value": {
-                                "template_id": "f33517ff-2a88-4f6e-b855-c550268ce08a",
+                                "template_id": "64415853-cb86-4cc4-b597-2aaa94ef8c39",
                                 "personalisation": {
-                                    "address_line_1": "The Occupier",
+                                    "address_line_1": "Amala Bird",
                                     "address_line_2": "123 High Street",
                                     "address_line_3": "Richmond upon Thames",
                                     "address_line_4": "Middlesex",
                                     "address_line_5": "SW14 6BF",
-                                    "address_line_6": "string",
-                                    "address_line_7": "string",
-                                    "name": "John Smith",
-                                    "application_id": "4134325",
+                                    "name": "Amala",
+                                    "appointment_date": "1 January 2018 at 1:00PM",
                                     "required_documents": [
                                         "passport",
                                         "utility bill",
                                         "other id"
                                     ]
                                 },
-                                "reference": "STRING"
+                                "reference": "your reference"
                             }
                         },
                         "Precompiled Letter": {
                             "value": {
-                                "reference": "STRING",
-                                "content": "base64EncodedPDFFile",
+                                "reference": "your reference",
+                                "content": "file as base64 encoded string",
                                 "postage": "second"
                             }
                         }
@@ -54,26 +52,26 @@
                         "examples": {
                             "Letter": {
                                 "value": {
-                                    "id": "740e5834-3a29-46b4-9a6f-16142fde533a",
-                                    "reference": "STRING",
+                                    "id": "3d1ce039-5476-414c-99b2-fac1e6add62c",
+                                    "reference": "your reference",
                                     "content": {
-                                        "subject": "SUBJECT TEXT",
-                                        "body": "LETTER TEXT"
+                                        "subject": "Your upcoming pigeon registration appointment",
+                                        "body": "Dear Amala\r\n\r\nYour pigeon registration appointment is scheduled for 1 January 2018 at 1:00PM.\r\n\r\nPlease bring:\r\n\n\n* passport\n* utility bill\n* other id\r\n\r\nYours,\r\nPigeon Affairs Bureau"
                                     },
-                                    "uri": "https://api.notifications.service.gov.uk/v2/notifications/740e5834-3a29-46b4-9a6f-16142fde533a",
+                                    "uri": "https://api.notifications.service.gov.uk/v2/notifications/3d1ce039-5476-414c-99b2-fac1e6add62c",
                                     "template": {
-                                        "id": "f33517ff-2a88-4f6e-b855-c550268ce08a",
-                                        "version": 1,
-                                        "uri": "https://api.notifications.service.gov.uk/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a"
+                                        "id": "64415853-cb86-4cc4-b597-2aaa94ef8c39",
+                                        "version": 3,
+                                        "uri": "https://api.notifications.service.gov.uk/v2/template/64415853-cb86-4cc4-b597-2aaa94ef8c39"
                                     },
                                     "scheduled_for": null
                                 }
                             },
                             "Precompiled Letter": {
                                 "value": {
-                                    "id": "740e5834-3a29-46b4-9a6f-16142fde533a",
-                                    "reference": "your-letter-reference",
-                                    "postage": "postage-you-have-set-or-default"
+                                    "id": "1d986ba7-fba6-49fb-84e5-75038a1dd968",
+                                    "reference": "your reference",
+                                    "postage": "second"
                                 }
                             }
                         }
@@ -86,20 +84,141 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/SendNotificaitonRequestError"
+                        },
+                        "examples": {
+                            "Personalisation required property": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "personalisation address_line_1 is a required property"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Must be a real UK postcode": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "Must be a real UK postcode"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Must be a real address": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "Must be a real address"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Last line of address must be a postcode or country": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "Last line of address must be a real UK postcode or another country"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Last line of a BFPO address must not be a country": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "The last line of a BFPO address must not be a country"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Address must be at least 3 lines": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "Address must be at least 3 lines"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Address must be no more than 7 lines": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "Address must be no more than 7 lines"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Address lines most not start with special characters": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "Address lines must not start with any of the following characters: @ ( ) = [ ] \" \\ / , < >"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Postage invalid": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "postage invalid. It must be either first, second or economy"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Cannot send letters when service is in trial mode": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Service is not allowed to send letters": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Service is not allowed to send letters"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Letter contact id does not exist": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "letter_contact_id <letter_contact_id> does not exist in database for service id <service id>"
+                                    }],
+                                    "status_code": 400
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/AuthError"
+                        },
+                        "examples": {
+                            "Cannot send letters with a team api key": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Cannot send letters with a team api key"
+                                    }],
+                                    "status_code": 403
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "429": {
                 "content": {
@@ -109,7 +228,7 @@
                         }
                     }
                 },
-                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed."
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "security": [

--- a/openapi/POST_notification_sms.json
+++ b/openapi/POST_notification_sms.json
@@ -29,10 +29,84 @@
                     "application/json": {
                         "schema": {
                             "$ref": "schema.json#/components/schemas/SendNotificaitonRequestError"
+                        },
+                        "examples": {
+                            "Too Many Digits": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "phone_number Too many digits"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Not Enough Digits": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "phone_number Not enough digits"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Not a UK mobile number": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "phone_number Not a UK mobile number"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Must not contain letters": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "phone_number Must not contain letters or symbols"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Not a valid country prefix": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "phone_number Not a valid country prefix"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Sender ID does not exist": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "sms_sender_id <sms_sender_id> does not exist in database for service id <service id>"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Trial mode": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Cannot send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
+                            "Cannot send to international": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "BadRequestError",
+                                        "message": "Cannot send to international mobile numbers"
+                                    }],
+                                    "status_code": 400
+                                }
+                            }
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed.  In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -42,7 +116,7 @@
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed.  For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "429": {
                 "content": {
@@ -52,7 +126,7 @@
                         }
                     }
                 },
-                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed."
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "500": {
                 "content": {
@@ -62,7 +136,7 @@
                         }
                     }
                 },
-                "description": "Internal server error. Check the `message` in the response to find out why your request failed."
+                "description": "Internal server error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "callbacks": {

--- a/openapi/POST_notification_sms.json
+++ b/openapi/POST_notification_sms.json
@@ -166,7 +166,7 @@
                         },
                         "security": [
                             {
-                                "BearerAuth": []
+                                "BearerToken": []
                             }
                         ],
                         "summary": "Text message callback"

--- a/openapi/POST_template_preview.json
+++ b/openapi/POST_template_preview.json
@@ -10,7 +10,7 @@
             "schema": {
                 "$ref": "schema.json#/components/schemas/TemplateByIdRequest"
             },
-            "example": "b7a59abd-0ab2-4538-b619-8da9f9089e08"  
+            "example": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3a"  
         }],
         "requestBody": {
             "content": {
@@ -32,7 +32,7 @@
                         }
                     }
                 },
-                "description": "Created"
+                "description": "If the request is successful, the response body is `json` and the status code is `200`"
             },
             "400": {
                 "content": {
@@ -42,7 +42,7 @@
                         }
                     }
                 },
-                "description": "Bad request. Check the `message` in the response to find out why your request failed."
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "403": {
                 "content": {
@@ -52,7 +52,7 @@
                         }
                     }
                 },
-                "description": "Auth error. Check the `message` in the response to find out why your request failed."
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "429": {
                 "content": {
@@ -62,7 +62,7 @@
                         }
                     }
                 },
-                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed."
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             },
             "500": {
                 "content": {
@@ -72,7 +72,7 @@
                         }
                     }
                 },
-                "description": "Internal server error. Check the `message` in the response to find out why your request failed."
+                "description": "Internal server error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors."
             }
         },
         "security": [

--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -77,8 +77,14 @@
             "BearerAuth": {
                 "description": "The authorisation header is an [API key](#api-keys) that is encoded using [JSON Web Tokens](https://jwt.io/). You must include an authorisation header.\n\nJSON Web Tokens have a standard header and a payload. The header consists of:\n\n```json\n{\n   \"type\":\"JWT\",\n   \"alg\":\"HS256\"\n}\n```\n\nThe payload consists of:\n\n```json\n{\n   \"iss\": \"26785a09-ab16-4eb0-8407-a37497a57506\",\n   \"iat\": 1568818578\n}\n```\n\nJSON Web Tokens are encoded using a secret key with the following format: ```3d844edf-8d35-48ac-975b-e847b4f122b0```\n\nThat secret key forms a part of your [API key](#api-keys), which follows the format\n\n`{key_name}-{iss-uuid}-{secret-key-uuid}`.\n\nFor example, if your API key is\n\n`my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`: \n\n* your API key name is `my_test_key` \n * your iss (your service id) is `26785a09-ab16-4eb0-8407-a37497a57506` \n * your secret key is `3d844edf-8d35-48ac-975b-e847b4f122b0` \n\n`iat` (issued at) is the current time in UTC in epoch seconds. The token expires within 30 seconds of the current time. \n\nRefer to the [JSON Web Tokens website](https://jwt.io/) for more information on encoding your authorisation header.\n\nWhen you have an encoded and signed token, add that token to a header as follows:\n\n```json\n\"Authorization\": \"Bearer encoded_jwt_token\"\n```",
                 "scheme": "bearer",
+                "type": "http",
+                "bearerFormat": "JWT"
+            },
+            "BearerToken": {
+                "description": "Callback requests POST requests will include the following header: \n\n ```json\n\"Authorization\": \"Bearer bearer_token_configured_in_Notify_admin_portal>\"\n```\n\n For more information please see the [callbacks section of the REST API documentation.](https://docs.notifications.service.gov.uk/rest-api.html#callbacks)\n\n",
+                "scheme": "bearer",
                 "type": "http"
             }
-        }
+        }     
     }
 }

--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -9,7 +9,7 @@
             "url": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         },
         "x-logo": {
-            "url": "https://assets.publishing.service.gov.uk/media/65d342e5e1bdec7737322247/s300_Untitled__1_.png",
+            "url": "https://assets.publishing.service.gov.uk/media/685a6183f05cab1603ade695/GOV.UK_updated_brand_logo_lock_up.jpg",
             "altText": "GOV.UK Notify"
         }
     },

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -55,14 +55,14 @@
                     "email_address": {
                         "type": "string",
                         "description": "The email address of the recipient.",
-                        "example": "sender@something.com",
+                        "example": "amala@example.com",
                         "maxLength": 250,
                         "minLength": 5
                     },
                     "template_id": {
                         "type": "string",
                         "description": "To find the template ID:\n\n1.  [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).\n2.  Go to the **Templates** page and select the relevant template.\n3.  Select **Copy template ID to clipboard**.",
-                        "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"
+                        "example": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3"
                     },
                     "one_click_unsubscribe_url": {
                         "type": "string",
@@ -71,15 +71,15 @@
                     },
                     "personalisation": {
                         "type": "object",
-                        "description": "You can leave out this argument if a template does not have any placeholder fields for personalised information.\n\nIf a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a dictionary with key value pairs. For example:",
+                        "description": "You can leave out this argument if a template does not have any placeholder fields for personalised information.\n\nIf a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a dictionary with key value pairs. Find out how to [reduce the risk of malicious content injection in placeholders](https://docs.notifications.service.gov.uk/rest-api.html#reducing-the-risk-of-malicious-content-injection-in-placeholders)",
                         "properties": {
                             "first_name": {
                                 "type": "string",
                                 "example": "Amala"
                             },
-                            "application_date": {
+                            "appointment_date": {
                                 "type": "string",
-                                "example": "2018-01-01"
+                                "example": "1 January 2018 at 1:00PM"
                             },
                             "required_documents": {
                                 "type": "array",
@@ -107,7 +107,7 @@
                                         "type": "string",
                                         "description": "File name",
                                         "maxLength": 100,
-                                        "example": "report.csv"
+                                        "example": "amala_pigeon_affairs_bureau_invite.csv"
                                     },
                                     "confirm_email_before_download": {
                                         "type": "boolean",
@@ -129,12 +129,12 @@
                     "reference": {
                         "type": "string",
                         "description": "You can leave out this argument if you do not have a reference.\n\nAn identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address.",
-                        "example": "STRING"
+                        "example": "your reference"
                     },
                     "email_reply_to_id": {
                         "type": "string",
                         "description": "You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.\n\nThis is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.\n\nTo add a reply-to email address:\n\n1.  [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).\n2.  Go to the **Settings** page.\n3.  In the **Email** section, select **Manage** on the **Reply-to email addresses** row.\n4.  Select **Add reply-to address**.\n5.  Enter the email address you want to use, and select **Add**.",
-                        "example": "STRING"
+                        "example": "8e222534-7f05-4972-86e3-17c5d9f894e2"
                     }
                 },
                 "required": [
@@ -759,11 +759,11 @@
                 "properties": {
                     "id": {
                         "type": "string",
-                        "example": "740e5834-3a29-46b4-9a6f-16142fde533a"
+                        "example": "201b576e-c09b-467b-9dfa-9c3b689ee730"
                     },
                     "reference": {
                         "type": "string",
-                        "example": "STRING"
+                        "example": "your reference"
                     },
                     "scheduled_for": {
                         "type": "string",
@@ -775,15 +775,15 @@
                         "properties": {
                             "subject": {
                                 "type": "string",
-                                "example": "SUBJECT TEXT"
+                                "example": "Your upcoming pigeon registration appointment"
                             },
                             "body": {
                                 "type": "string",
-                                "example": "MESSAGE TEXT"
+                                "example": "Dear Amala\r\n\r\nYour pigeon registration appointment is scheduled for 1 January 2018 at 1:00PM.\r\n\r\nPlease bring:\r\n\n\n* passport\n* utility bill\n* other id\r\n\r\nYours,\r\nPigeon Affairs Bureau"
                             },
                             "from_email": {
                                 "type": "string",
-                                "example": "SENDER EMAIL"
+                                "example": "pigeon.affairs.bureau@notifications.service.gov.uk"
                             },
                             "one_click_unsubscribe_url": {
                                 "type": "string",
@@ -794,14 +794,14 @@
                     },
                     "uri": {
                         "type": "string",
-                        "example": "https://api.notifications.service.gov.uk/v2/notifications/740e5834-3a29-46b4-9a6f-16142fde533a"
+                        "example": "https://api.notifications.service.gov.uk/v2/notifications/201b576e-c09b-467b-9dfa-9c3b689ee730"
                     },
                     "template": {
                         "type": "object",
                         "properties": {
                             "id": {
                                 "type": "string",
-                                "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"
+                                "example": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3"
                             },
                             "version": {
                                 "type": "number",
@@ -809,7 +809,7 @@
                             },
                             "uri": {
                                 "type": "string",
-                                "example": "https://api.notifications.service.gov.uk/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a"
+                                "example": "https://api.notifications.service.gov.uk/v2/template/9d751e0e-f929-4891-82a1-a3e1c3c18ee3"
                             }
                         }
                     }

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -385,6 +385,62 @@
                 },
                 "required": []
             },
+            "LetterCallbackRequest": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "example": "3d1ce039-5476-414c-99b2-fac1e6add62c",
+                        "description": "Notify's ID for the returned letter"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "example": "your reference",
+                        "description": "The reference sent by the service"
+                    },
+                    "date_sent": {
+                        "type": "string",
+                        "example": "2023-09-16T16:50:09.090424Z",
+                        "description": "The time the letter was sent"
+                    },
+                    "sent_by": {
+                        "type": "string",
+                        "example": "hello@gov.uk or null",
+                        "description": "The email address of the service member who sent the letter"
+                    },
+                    "template_name": {
+                        "type": "string",
+                        "example": "Appointment confirmation",
+                        "description": "The name of the template that was used"
+                    },
+                    "template_id": {
+                        "type": "string",
+                        "example": "64415853-cb86-4cc4-b597-2aaa94ef8c39",
+                        "description": "The id of the template that was used"
+                    },
+                    "template_version": {
+                        "type": "number",
+                        "example": 3,
+                        "description": "The version number of the template that was used"
+                    },
+                    "spreadsheet_file_name": {
+                        "type": "string",
+                        "example": "contact_list.csv or null",
+                        "description": "The name of the uploaded spreadsheet"
+                    },
+                     "spreadsheet_row_number": {
+                        "type": "number",
+                        "example": 2,
+                        "description": "The row in the spreadsheet"
+                    },
+                    "upload_letter_file_name": {
+                        "type": "string",
+                        "example": "upload_letter.pdf or null",
+                        "description": "The name of the uploaded letter"
+                    }
+                },
+                "required": []
+            },
             "GetMultipleMessagesResponse": {
                 "type": "object",
                 "description": "The Send Text Message Response Payload",

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -341,15 +341,15 @@
                 "properties": {
                     "id": {
                         "type": "string",
-                        "example": "75a36070-55dc-4dc1-ac33-89da9377d989"
+                        "example": "740e5834-3a29-46b4-9a6f-16142fde533a"
                     },
                     "reference": {
                         "type": "string",
-                        "example": null
+                        "example": "your reference"
                     },
                     "to": {
                         "type": "string",
-                        "example": "07777777777"
+                        "example": "+447900900123"
                     },
                     "status": {
                         "type": "string",
@@ -373,11 +373,11 @@
                     },
                     "template_id": {
                         "type": "string",
-                        "example": "8496188f-3f35-401b-9b8c-f97a528c5b76"
+                        "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"
                     },
                     "template_version": {
                         "type": "number",
-                        "example": 1
+                        "example": 3
                     }
                 },
                 "required": []

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -1858,12 +1858,11 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
-                                    "example": "NoResultFound"
+                                    "description": "Error type"
                                 },
                                 "message": {
                                     "type": "string",
-                                    "example": "id is not a valid UUID",
-                                    "description": "Check the notification ID"
+                                    "description": "Error message"
                                 }
                             }
                         }

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -473,212 +473,592 @@
                 }
             },
             "GetOneMessageResponse": {
-                "type": "object",
-                "description": "The Send Email Response Payload",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Required - notification ID",
-                        "example": "740e5834-3a29-46b4-9a6f-16142fde533a"
-                    },
-                    "reference": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Optional",
-                        "example": "STRING"
-                    },
-                    "email_address": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for emails",
-                        "example": "sender@something.com"
-                    },
-                    "phone_number": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for text messages",
-                        "example": "+447900900123"
-                    },
-                    "line_1": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "example": "ADDRESS LINE 1"
-                    },
-                    "line_2": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "example": "ADDRESS LINE 2"
-                    },
-                    "line_3": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "example": "ADDRESS LINE 3"
-                    },
-                    "line_4": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "example": "ADDRESS LINE 4"
-                    },
-                    "line_5": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "example": "ADDRESS LINE 5"
-                    },
-                    "line_6": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "example": "ADDRESS LINE 6"
-                    },
-                    "postcode": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "example": "NW1 2TZ"
-                    },
-                    "postage": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for letter",
-                        "enum": [
-                            "first",
-                            "second",
-                            "economy",
-                            "europe",
-                            "rest-of-world"
-                        ],
-                        "example": "first / second / economy / europe / rest-of-world"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "Required",
-                        "enum": [
-                            "sms",
-                            "letter",
-                            "email"
-                        ],
-                        "example": "sms / letter / email"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Required",
-                        "example": "sending / delivered / permanent-failure / temporary-failure / technical-failure"
-                    },
-                    "template": {
+                "oneOf": [
+                    {
+                        "title": "sms",
                         "type": "object",
+                        "description": "Get status of SMS - response payload",
                         "properties": {
                             "id": {
                                 "type": "string",
-                                "description": "Required - template ID",
-                                "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"
+                                "description": "required string - notification ID",
+                                "example": "740e5834-3a29-46b4-9a6f-16142fde533a"
                             },
-                            "version": {
-                                "type": "number",
-                                "example": 1
-                            },
-                            "uri": {
+                            "reference": {
                                 "type": "string",
-                                "description": "Required",
-                                "example": "/v2/template/{id}/{version}"
-                            }
-                        }
-                    },
-                    "body": {
-                        "type": "string",
-                        "description": "Required - body of notification",
-                        "example": "STRING"
-                    },
-                    "subject": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Required for email- subject of email",
-                        "example": "STRING"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "description": "Required - date and time notification created",
-                        "example": "2024-05-17T15:58:38.342838Z"
-                    },
-                    "created_by_name": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Optional - name of the person who sent the notification if sent manually",
-                        "example": "STRING"
-                    },
-                    "sent_at": {
-                        "type": "string",
-                        "description": "Optional - date and time notification sent to provider",
-                        "example": "2024-05-17T15:58:30.143000Z"
-                    },
-                    "completed_at": {
-                        "type": "string",
-                        "description": "Optional - date and time notification delivered or failed",
-                        "example": "2024-05-17T15:59:10.321000Z"
-                    },
-                    "scheduled_for": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Optional - date and time notification has been scheduled to be sent at",
-                        "example": "2024-05-17T09:00:00.000000Z"
-                    },
-                    "one_click_unsubscribe_url": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Optional - URL that you provided so your recipients can unsubscribe",
-                        "example": "STRING"
-                    },
-                    "is_cost_data_ready": {
-                        "type": "boolean",
-                        "description": "`true` if cost data is ready, and `false` if it isn't",
-                        "example": true
-                    },
-                    "cost_in_pounds": {
-                        "type": "number",
-                        "format": "float",
-                        "description": "Optional - cost of the notification in pounds. The cost does not take free allowance into account",
-                        "example": 0.0027
-                    },
-                    "cost_details": {
-                        "oneOf": [
-                            {
+                                "nullable": true,
+                                "description": "optional string - reference you provided when sending the message",
+                                "example": "your reference"
+                            },
+                            "email_address": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "phone_number": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string for text messages",
+                                "example": "+447900900123"
+                            },
+                            "line_1": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "line_2": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "line_3": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "line_4": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "line_5": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "line_6": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "postcode": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "postage": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "enum": [
+                                    "first",
+                                    "second",
+                                    "economy",
+                                    "europe",
+                                    "rest-of-world"
+                                ],
+                                "example": null
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "required string",
+                                "enum": [
+                                    "sms",
+                                    "letter",
+                                    "email"
+                                ],
+                                "example": "sms"
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "required string - see [REST API document](https://docs.notifications.service.gov.uk/rest-api.html#text-message-status-descriptions) for a detailed description.",
+                                "enum": [
+                                    "created",
+                                    "sending",
+                                    "pending",
+                                    "sent",
+                                    "delivered",
+                                    "permanent-failure",
+                                    "temporary-failure",
+                                    "technical-failure"
+                                ],
+                                "example": "delivered"
+                            },
+                            "template": {
                                 "type": "object",
-                                "title": "sms",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "required string - template ID",
+                                        "example": "f33517ff-2a88-4f6e-b855-c550268ce08aa"
+                                    },
+                                    "version": {
+                                        "type": "number",
+                                        "description": "required integer",
+                                        "example": 3
+                                    },
+                                    "uri": {
+                                        "type": "string",
+                                        "description": "required string",
+                                        "example": "https://api.notifications.service.gov.uk/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a/version/3"
+                                    }
+                                }
+                            },
+                            "body": {
+                                "type": "string",
+                                "description": "required string - body of notification",
+                                "example": "Hi Amala, your appointment is on 1 January 2018 at 1:00PM"
+                            },
+                            "subject": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "description": "required string - date and time notification created",
+                                "example": "2024-05-17T15:58:38.342838Z"
+                            },
+                            "created_by_name": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - name of the person who sent the notification if sent manually",
+                                "example": "Charlie Smith"
+                            },
+                            "sent_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification sent to provider",
+                                "example": "2024-05-17T15:58:30.143000Z"
+                            },
+                            "completed_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification delivered or failed",
+                                "example": "2024-05-17T15:59:10.321000Z"
+                            },
+                            "scheduled_for": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - date and time notification has been scheduled to be sent at",
+                                "example": "2024-05-17T09:00:00.000000Z"
+                            },
+                            "one_click_unsubscribe_url": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for SMS",
+                                "example": null
+                            },
+                            "is_cost_data_ready": {
+                                "type": "boolean",
+                                "description": "required boolean, this field is `true` if cost data is ready, and `false` if it isn't",
+                                "example": true
+                            },
+                            "cost_in_pounds": {
+                                "type": "number",
+                                "format": "float",
+                                "description": "optional number - cost of the notification in pounds. The cost does not take free allowance into account",
+                                "example": 0.0233
+                            },
+                            "cost_details": {
+                                "type": "object",
                                 "properties": {
                                     "billable_sms_fragments": {
                                         "type": "number",
-                                        "description": "Optional - for text messages, number of billable sms fragments in your text message",
+                                        "description": "optional integer - number of billable sms fragments in your text message",
                                         "example": 1
                                     },
                                     "international_rate_multiplier": {
                                         "type": "number",
-                                        "description": "Optional - for text messages, for international sms rate is multiplied by this value",
-                                        "example": 1
+                                        "format": "float",
+                                        "description": "optional integer - for international sms rate is multiplied by this value",
+                                        "example": 1.0
                                     },
                                     "sms_rate": {
                                         "type": "number",
                                         "format": "float",
-                                        "description": "Optional - for text messages, cost of 1 sms fragment",
-                                        "example": 0.0027
+                                        "description": "optional number - cost of 1 sms fragment",
+                                        "example": 0.0233
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "title": "email",
+                        "type": "object",
+                        "description": "Get status of email - response payload",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "required string - notification ID",
+                                "example": "201b576e-c09b-467b-9dfa-9c3b689ee730"
+                            },
+                            "reference": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - reference you provided when sending the message",
+                                "example": "your reference"
+                            },
+                            "email_address": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string for emails",
+                                "example": "amala@example.com"
+                            },
+                            "phone_number": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "line_1": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "line_2": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "line_3": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "line_4": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "line_5": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "line_6": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "postcode": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "example": null
+                            },
+                            "postage": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for emails",
+                                "enum": [
+                                    "first",
+                                    "second",
+                                    "economy",
+                                    "europe",
+                                    "rest-of-world"
+                                ],
+                                "example": null
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "required string",
+                                "enum": [
+                                    "sms",
+                                    "letter",
+                                    "email"
+                                ],
+                                "example": "email"
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "required string - see [REST API document](https://docs.notifications.service.gov.uk/rest-api.html#email-status-descriptions) for a detailed description.",
+                                "enum": [
+                                    "created",
+                                    "sending",
+                                    "delivered",
+                                    "permanent-failure",
+                                    "temporary-failure",
+                                    "technical-failure"
+                                ],
+                                "example": "delivered"
+                            },
+                            "template": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "required string - template ID",
+                                        "example": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3a"
+                                    },
+                                    "version": {
+                                        "type": "number",
+                                        "description": "required integer",
+                                        "example": 1
+                                    },
+                                    "uri": {
+                                        "type": "string",
+                                        "description": "required string",
+                                        "example": "https://api.notifications.service.gov.uk/v2/template/9d751e0e-f929-4891-82a1-a3e1c3c18ee3/version/1"
                                     }
                                 }
                             },
-                            {
+                            "body": {
+                                "type": "string",
+                                "description": "required string - body of notification",
+                                "example": "Dear Amala\r\n\r\nYour pigeon registration appointment is scheduled for 1 January 2018 at 1:00PM.\r\n\r\nPlease bring:\r\n\n\n* passport\n* utility bill\n* other id\r\n\r\nYours,\r\nPigeon Affairs Bureau"
+                            },
+                            "subject": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string - email subject",
+                                "example": "Your upcoming pigeon registration appointment"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "description": "required string - date and time notification created",
+                                "example": "2024-05-17T15:58:38.342838Z"
+                            },
+                            "created_by_name": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - name of the person who sent the notification if sent manually",
+                                "example": "Charlie Smith"
+                            },
+                            "sent_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification sent to provider",
+                                "example": "2024-05-17T15:58:30.143000Z"
+                            },
+                            "completed_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification delivered or failed",
+                                "example": "2024-05-17T15:59:10.321000Z"
+                            },
+                            "scheduled_for": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - date and time notification has been scheduled to be sent at",
+                                "example": "2024-05-17T09:00:00.000000Z"
+                            },
+                            "one_click_unsubscribe_url": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - URL that you provided so your recipients can unsubscribe",
+                                "example": "https://example.com/unsubscribe.html?opaque=123456789"
+                            },
+                            "is_cost_data_ready": {
+                                "type": "boolean",
+                                "description": "required boolean, this field is `true` if cost data is ready, and `false` if it isn't",
+                                "example": true
+                            },
+                            "cost_in_pounds": {
+                                "type": "number",
+                                "format": "float",
+                                "description": "optional number - cost of the notification in pounds. The cost does not take free allowance into account",
+                                "example": 0.0
+                            },
+                            "cost_details": {
                                 "type": "object",
-                                "title": "letter",
+                                "properties": {
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "title": "letter",
+                        "type": "object",
+                        "description": "Get status of letter - response payload",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "required string - notification ID",
+                                "example": "3d1ce039-5476-414c-99b2-fac1e6add62c"
+                            },
+                            "reference": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - reference you provided when sending the message",
+                                "example": "your reference"
+                            },
+                            "email_address": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for letters",
+                                "example": null
+                            },
+                            "phone_number": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for letters",
+                                "example": null
+                            },
+                            "line_1": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string",
+                                "example": "Amala Bird"
+                            },
+                            "line_2": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string",
+                                "example": "123 High Street"
+                            },
+                            "line_3": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string",
+                                "example": "Richmond upon Thames"
+                            },
+                            "line_4": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string",
+                                "example": "Middlesex"
+                            },
+                            "line_5": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string",
+                                "example": "SW14 6BF"
+                            },
+                            "line_6": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string",
+                                "example": null
+                            },
+                            "postcode": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string",
+                                "example": null
+                            },
+                            "postage": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string",
+                                "enum": [
+                                    "first",
+                                    "second",
+                                    "economy",
+                                    "europe",
+                                    "rest-of-world"
+                                ],
+                                "example": "second"
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "required string",
+                                "enum": [
+                                    "sms",
+                                    "letter",
+                                    "email"
+                                ],
+                                "example": "letter"
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "required string - see [REST API document](https://docs.notifications.service.gov.uk/rest-api.html#letter-status-descriptions) for a detailed description.",
+                                "enum": [
+                                    "accepted",
+                                    "received",
+                                    "cancelled",
+                                    "permanent-failure",
+                                    "technical-failure"
+                                ],
+                                "example": "accepted"
+                            },
+                            "template": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "required string - template ID",
+                                        "example": "64415853-cb86-4cc4-b597-2aaa94ef8c39"
+                                    },
+                                    "version": {
+                                        "type": "number",
+                                        "description": "required integer",
+                                        "example": 3
+                                    },
+                                    "uri": {
+                                        "type": "string",
+                                        "description": "required string",
+                                        "example": "https://api.notifications.service.gov.uk/v2/template/64415853-cb86-4cc4-b597-2aaa94ef8c39/version/3"
+                                    }
+                                }
+                            },
+                            "body": {
+                                "type": "string",
+                                "description": "required string - body of notification",
+                                "example": "Dear Amala\r\n\r\nYour pigeon registration appointment is scheduled for 1 January 2018 at 1:00PM.\r\n\r\nPlease bring:\r\n\n\n* passport\n* utility bill\n* other id\r\n\r\nYours,\r\nPigeon Affairs Bureau"
+                            },
+                            "subject": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string - letter heading",
+                                "example": "Your upcoming pigeon registration appointment"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "description": "required string - date and time notification created",
+                                "example": "2024-05-17T15:58:38.342838Z"
+                            },
+                            "created_by_name": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - name of the person who sent the notification if sent manually",
+                                "example": "Charlie Smith"
+                            },
+                            "sent_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification sent to provider",
+                                "example": "2024-05-17T15:58:30.143000Z"
+                            },
+                            "completed_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification delivered or failed",
+                                "example": "2024-05-17T15:59:10.321000Z"
+                            },
+                            "scheduled_for": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - date and time notification has been scheduled to be sent at",
+                                "example": "2024-05-17T09:00:00.000000Z"
+                            },
+                            "one_click_unsubscribe_url": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for letters",
+                                "example": null
+                            },
+                            "is_cost_data_ready": {
+                                "type": "boolean",
+                                "description": "required boolean, this field is `true` if cost data is ready, and `false` if it isn't",
+                                "example": true
+                            },
+                            "cost_in_pounds": {
+                                "type": "number",
+                                "format": "float",
+                                "description": "optional number - cost of the notification in pounds. The cost does not take free allowance into account",
+                                "example": 0.68
+                            },
+                            "cost_details": {
+                                "type": "object",
                                 "properties": {
                                     "billable_sheets_of_paper": {
                                         "type": "number",
-                                        "description": "Optional - for letters, number of sheets of paper in the letter you sent",
-                                        "example": 2
+                                        "description": "optional integer - number of billable sheets of paper in your letter",
+                                        "example": 1
                                     },
                                     "postage": {
                                         "type": "string",
-                                        "description": "Optional - for letters",
                                         "enum": [
                                             "first",
                                             "second",
@@ -686,18 +1066,221 @@
                                             "europe",
                                             "rest-of-world"
                                         ],
-                                        "example": "first / second / economy / europe / rest-of-world"
+                                        "description": "optional string",
+                                        "example": "second"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "title": "precompiled letter",
+                        "type": "object",
+                        "description": "Get status of precompiled letter - response payload",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "required string - notification ID",
+                                "example": "1d986ba7-fba6-49fb-84e5-75038a1dd968"
+                            },
+                            "reference": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - reference you provided when sending the message",
+                                "example": "your reference"
+                            },
+                            "email_address": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for letters",
+                                "example": null
+                            },
+                            "phone_number": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for letters",
+                                "example": null
+                            },
+                            "line_1": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string for precompiled letter - may be \"Provided as PDF\" until the PDF is processed Notify",
+                                "example": "Amala Bird"
+                            },
+                            "line_2": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string for letter - may be null if line_1 is \"Provided as PDF\"",
+                                "example": "123 High Street"
+                            },
+                            "line_3": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string for letter - may be null if line_1 is \"Provided as PDF\"",
+                                "example": "Richmond upon Thames"
+                            },
+                            "line_4": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string for letter",
+                                "example": "Middlesex"
+                            },
+                            "line_5": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string for letter",
+                                "example": "SW14 6BF"
+                            },
+                            "line_6": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string for letter",
+                                "example": null
+                            },
+                            "postcode": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string for letter",
+                                "example": null
+                            },
+                            "postage": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string for letter",
+                                "enum": [
+                                    "first",
+                                    "second",
+                                    "economy",
+                                    "europe",
+                                    "rest-of-world"
+                                ],
+                                "example": "first"
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "required string",
+                                "enum": [
+                                    "sms",
+                                    "letter",
+                                    "email"
+                                ],
+                                "example": "letter"
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "required string - see [REST API document](https://docs.notifications.service.gov.uk/rest-api.html#precompiled-letter-status-descriptions) for a detailed description.",
+                                "enum": [
+                                    "accepted",
+                                    "received",
+                                    "cancelled",
+                                    "pending-virus-check",
+                                    "virus-scan-failed",
+                                    "validation-failed",
+                                    "permanent-failure",
+                                    "technical-failure"
+                                ],
+                                "example": "accepted"
+                            },
+                            "template": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "required string - template ID - This is an internal Notify template for precompiled letters",
+                                        "example": "92b24f9c-bee1-47f8-a387-f19feb302d70"
+                                    },
+                                    "version": {
+                                        "type": "number",
+                                        "description": "required integer",
+                                        "example": 1
+                                    },
+                                    "uri": {
+                                        "type": "string",
+                                        "description": "required string - This is an internal Notify template for precompiled letters",
+                                        "example": "https://api.notifications.service.gov.uk/v2/template/92b24f9c-bee1-47f8-a387-f19feb302d70/version/1"
                                     }
                                 }
                             },
-                            {
+                            "body": {
+                                "type": "string",
+                                "description": "empty string for precompiled letter",
+                                "example": ""
+                            },
+                            "subject": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "required string for precompiled letters - always set to \"Pre-compiled PDF\"",
+                                "example": "Pre-compiled PDF"
+                            },
+                            "created_at": {
+                                "type": "string",
+                                "description": "required string - date and time notification created",
+                                "example": "2024-05-17T15:58:38.342838Z"
+                            },
+                            "created_by_name": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - name of the person who sent the notification if sent manually",
+                                "example": null
+                            },
+                            "sent_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification sent to provider",
+                                "example": "2024-05-17T15:58:30.143000Z"
+                            },
+                            "completed_at": {
+                                "type": "string",
+                                "description": "optional string - date and time notification delivered or failed",
+                                "example": "2024-05-17T15:59:10.321000Z"
+                            },
+                            "scheduled_for": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "optional string - date and time notification has been scheduled to be sent at",
+                                "example": null
+                            },
+                            "one_click_unsubscribe_url": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "not required for letters",
+                                "example": null
+                            },
+                            "is_cost_data_ready": {
+                                "type": "boolean",
+                                "description": "required boolean, this field is `true` if cost data is ready, and `false` if it isn't",
+                                "example": true
+                            },
+                            "cost_in_pounds": {
+                                "type": "number",
+                                "format": "float",
+                                "description": "optional number - cost of the notification in pounds. The cost does not take free allowance into account",
+                                "example": 0.68
+                            },
+                            "cost_details": {
                                 "type": "object",
-                                "title": "email",
-                                "properties": {}
+                                "properties": {
+                                    "billable_sheets_of_paper": {
+                                        "type": "number",
+                                        "description": "optional integer - number of billable sheets of paper in your letter",
+                                        "example": 1
+                                    },
+                                    "postage": {
+                                        "type": "string",
+                                        "enum": [
+                                            "first",
+                                            "second",
+                                            "economy",
+                                            "europe",
+                                            "rest-of-world"
+                                        ],
+                                        "description": "optional string",
+                                        "example": "second"
+                                    }
+                                }
                             }
-                        ]
-                    }
-                }
+                        }
+                    }   
+                ]
             },
             "GetReceivedTextMessageResponse": {
                 "type": "object",

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -295,15 +295,15 @@
                 "properties": {
                     "id": {
                         "type": "string",
-                        "example": "75a36070-55dc-4dc1-ac33-89da9377d989"
+                        "example": "201b576e-c09b-467b-9dfa-9c3b689ee730"
                     },
                     "reference": {
                         "type": "string",
-                        "example": null
+                        "example": "your reference"
                     },
                     "to": {
                         "type": "string",
-                        "example": "example@mail.com"
+                        "example": "amala@example.com"
                     },
                     "status": {
                         "type": "string",
@@ -327,11 +327,11 @@
                     },
                     "template_id": {
                         "type": "string",
-                        "example": "8496188f-3f35-401b-9b8c-f97a528c5b76"
+                        "example": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3"
                     },
                     "template_version": {
                         "type": "number",
-                        "example": 2
+                        "example": 1
                     }
                 },
                 "required": []

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -1292,27 +1292,33 @@
                 "properties": {
                     "id": {
                         "type": "string",
-                        "example": "740e5834-3a29-46b4-9a6f-16142fde533a"
+                        "example": "b51f638b-4295-46e0-a06e-cd41eee7c33b",
+                        "description": "required string - ID of received text message"
                     },
                     "created_at": {
                         "type": "string",
-                        "example": "2024-05-17T15:58:38.342838Z"
+                        "example": "2024-12-12 18:39:16.123346",
+                        "description": "required string - date and time SMS received"
                     },
                     "service_id": {
                         "type": "string",
-                        "example": "STRING"
+                        "example": "26785a09-ab16-4eb0-8407-a37497a57506",
+                        "description": "required string - service ID"
                     },
                     "notify_number": {
                         "type": "string",
-                        "example": "STRING"
+                        "example": "07700900456",
+                        "description": "required string - your receiving number"
                     },
                     "user_number": {
                         "type": "string",
-                        "example": "STRING"
+                        "example": "447700900123",
+                        "description": "required string - number of the end user who sent the message"
                     },
                     "content": {
                         "type": "string",
-                        "example": "STRING"
+                        "example": "Hi, Please can I book an appointment. Amala",
+                        "description": "required string - text content"
                     }
                 }
             },
@@ -1322,7 +1328,7 @@
                 "properties": {
                     "received_text_messages": {
                         "type": "array",
-                        "description": "Multiple received text messages, empty if no text messages received",
+                        "description": "If the request is successful, the response body is `json` and the status code is `200`",
                         "items": {
                             "$ref": "#/components/schemas/GetReceivedTextMessageResponse"
                         }
@@ -1340,7 +1346,7 @@
                             },
                             "next": {
                                 "type": "string",
-                                "example": "https://api.notifications.service.gov.uk/v2/received-text-messages?older_than=last_id_in_list"
+                                "example": "https://api.notifications.service.gov.uk/v2/received-text-messages?older_than=b51f638b-4295-46e0-a06e-cd41eee7c33b"
                             }
                         }
                     }
@@ -2119,7 +2125,7 @@
             },
             "GetMessageValidationError": {
                 "type": "object",
-                "description": "Validation error response",
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors.",
                 "properties": {
                     "errors": {
                         "type": "array",
@@ -2128,11 +2134,13 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
+                                    "example": "ValidationError",
                                     "description": "Error type"
                                 },
                                 "message": {
                                     "type": "string",
-                                    "description": "Error message"
+                                    "description": "Error message",
+                                    "example": "older_than is not a valid UUID"
                                 }
                             }
                         }

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -392,7 +392,7 @@
             "LetterCallbackRequest": {
                 "type": "object",
                 "properties": {
-                    "id": {
+                    "notification_id": {
                         "type": "string",
                         "example": "3d1ce039-5476-414c-99b2-fac1e6add62c",
                         "description": "Notify's ID for the returned letter"

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -470,7 +470,7 @@
                             "next": {
                                 "type": "string",
                                 "description": "Optional property, only included if the query parameter filers return some data",
-                                "example": "https://api.notifications.service.gov.uk/v2/notifications?older_than=last_id_in_list&template_type=sms&status=delivered"
+                                "example": "https://api.notifications.service.gov.uk/v2/notifications?older_than=740e5834-3a29-46b4-9a6f-16142fde533a&template_type=sms&status=delivered"
                             }
                         }
                     }

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -167,7 +167,7 @@
                         "properties": {
                             "address_line_1": {
                                 "type": "string",
-                                "example": "The Occupier"
+                                "example": "Amala Bird"
                             },
                             "address_line_2": {
                                 "type": "string",
@@ -193,11 +193,13 @@
                             },
                             "name": {
                                 "type": "string",
-                                "example": "John Smith"
+                                "example": "Amala",
+                                "description": "example of personalisation field used by the template"
                             },
-                            "application_id": {
+                            "appointment_date": {
                                 "type": "string",
-                                "example": "4134325"
+                                "example": "1 January 2018 at 1:00PM",
+                                "description": "example of personalisation used by the template"
                             },
                             "required_documents": {
                                 "type": "array",
@@ -208,7 +210,8 @@
                                     "passport",
                                     "utility bill",
                                     "other id"
-                                ]
+                                ],
+                                "description": "example of personalisation used by the template"
                             }
                         },
                         "required": [
@@ -1243,7 +1246,7 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
-                                    "example": "BadRequestErrorr",
+                                    "example": "BadRequestError",
                                     "description": "Error type"
                                 },
                                 "message": {

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -267,7 +267,7 @@
             },
             "TemplateByIdRequest": {
                 "type": "string",
-                "example": "b7a59abd-0ab2-4538-b619-8da9f9089e08"
+                "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"
             },
             "TemplateByIdAndVersionRequest": {
                 "type": "integer",
@@ -588,7 +588,7 @@
                                     "id": {
                                         "type": "string",
                                         "description": "required string - template ID",
-                                        "example": "f33517ff-2a88-4f6e-b855-c550268ce08aa"
+                                        "example": "f33517ff-2a88-4f6e-b855-c550268ce08a"
                                     },
                                     "version": {
                                         "type": "number",
@@ -1551,91 +1551,282 @@
                 }
             },
             "TemplateResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "example": "f33517ff-2a88-4f6e-b855-c550268ce08a",
-                        "description": "required string - template ID"
-                    },
-                    "name": {
-                        "type": "string",
-                        "example": "Test template",
-                        "description": "required string - template name"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "sms",
-                            "email",
-                            "letter"
-                        ],
-                        "example": "sms",
-                        "description": "required string"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "example": "2024-08-12T10:40:20.000000Z",
-                        "description": "required string - date and time template created"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "example": "2024-08-12T10:45:47.890097Z",
-                        "description": "required string - date and time template last updated"
-                    },
-                    "version": {
-                        "type": "integer",
-                        "example": 3
-                    },
-                    "created_by": {
-                        "type": "string",
-                        "example": "someone@example.com",
-                        "description": "required string"
-                    },
-                    "body": {
-                        "type": "string",
-                        "example": "Hi ((firstname)), We have received your letter dated ((date)).  No further action is required.",
-                        "description": "required string - body of notification"
-                    },
-                    "subject": {
-                        "type": "string",
-                        "nullable": true,
-                        "example": "Test",
-                        "description": "required string for email - subject of email, otherwise null"
-                    },
-                    "postage": {
-                        "type": "string",
-                        "enum": [
-                            "first",
-                            "second",
-                            "economy",
-                            "europe",
-                            "rest-of-world",
-                            null
-                        ],
-                        "nullable": true,
-                        "example": "second",
-                        "description": "required string for letter - postage type, otherwise null"
-                    },
-                    "personalisation": {
-                        "type": "object",
-                        "example": {
-                            "date": {
-                                "required": true
-                            },
-                            "firstname": {
-                                "required": true
-                            }
+                "oneOf": [
+                {
+                    "title" : "sms",
+                    "type": "object",
+                    "description": "Get SMS template - response payload",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "example": "f33517ff-2a88-4f6e-b855-c550268ce08a",
+                            "description": "required string - template ID"
                         },
-                        "description": "object containaing personalisation parameters - empty if no personalisation in the template"
-                    },
-                    "letter_contact_block": {
-                        "type": "string",
-                        "nullable": true,
-                        "example": "",
-                        "description": "optional string - null if not a letter template or contact block not set"
+                        "name": {
+                            "type": "string",
+                            "example": "Pigeon registration - appointment SMS",
+                            "description": "required string - template name"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "sms",
+                                "email",
+                                "letter"
+                            ],
+                            "example": "sms",
+                            "description": "required string"
+                        },
+                        "created_at": {
+                            "type": "string",
+                            "example": "2024-05-10 10:30:31.142535Z",
+                            "description": "required string - date and time template created"
+                        },
+                        "updated_at": {
+                            "type": "string",
+                            "example": "2024-08-25 13:00:09.123234Z",
+                            "nullable": true,
+                            "description": "date and time template last updated or null"
+                        },
+                        "version": {
+                            "type": "integer",
+                            "example": 3
+                        },
+                        "created_by": {
+                            "type": "string",
+                            "example": "charlie.smith@pigeons.gov.uk",
+                            "description": "required string"
+                        },
+                        "body": {
+                            "type": "string",
+                            "example": "Hi ((firstname)), your appointment is on ((date))",
+                            "description": "required string - body of notification"
+                        },
+                        "subject": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": null,
+                            "description": "null for SMS templates"
+                        },
+                        "postage": {
+                            "type": "string",
+                            "enum": [
+                                "first",
+                                "second",
+                                "economy",
+                                "europe",
+                                "rest-of-world",
+                                null
+                            ],
+                            "nullable": true,
+                            "example": null,
+                            "description": "null for SMS templates"
+                        },
+                        "personalisation": {
+                            "type": "object",
+                            "example": {
+                                "date": {
+                                    "required": true
+                                },
+                                "firstname": {
+                                    "required": true
+                                }
+                            },
+                            "description": "object containing personalisation parameters - empty if no personalisation in the template"
+                        },
+                        "letter_contact_block": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": null,
+                            "description": "null for SMS templates"
+                        }
+                    }
+                },
+                {
+                    "title" : "email",
+                    "type": "object",
+                    "description": "Get Email template - response payload",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "example": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3a",
+                            "description": "required string - template ID"
+                        },
+                        "name": {
+                            "type": "string",
+                            "example": "Pigeon registration - appointment email",
+                            "description": "required string - template name"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "sms",
+                                "email",
+                                "letter"
+                            ],
+                            "example": "email",
+                            "description": "required string"
+                        },
+                        "created_at": {
+                            "type": "string",
+                            "example": "2024-05-10 10:30:31.142535Z",
+                            "description": "required string - date and time template created"
+                        },
+                        "updated_at": {
+                            "type": "string",
+                            "example": null,
+                            "nullable": true,
+                            "description": "date and time template last updated or null"
+                        },
+                        "version": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "created_by": {
+                            "type": "string",
+                            "example": "charlie.smith@pigeons.gov.uk",
+                            "description": "required string"
+                        },
+                        "body": {
+                            "type": "string",
+                            "example": "Dear ((first_name))\r\n\r\nYour pigeon registration appointment is scheduled for ((appointment_date)).\r\n\r\nPlease bring:\r\n\n\n((required_documents))\r\n\r\nYours,\r\nPigeon Affairs Bureau",
+                            "description": "required string - body of notification"
+                        },
+                        "subject": {
+                            "type": "string",
+                            "example": "Your upcoming pigeon registration appointment",
+                            "description": "required string for email templates - email subject"
+                        },
+                        "postage": {
+                            "type": "string",
+                            "enum": [
+                                "first",
+                                "second",
+                                "economy",
+                                "europe",
+                                "rest-of-world",
+                                null
+                            ],
+                            "nullable": true,
+                            "example": null,
+                            "description": "null for email templates"
+                        },
+                        "personalisation": {
+                            "type": "object",
+                            "example": {
+                                "appointment_date": {
+                                    "required": true
+                                },
+                                "first_name": {
+                                    "required": true
+                                },
+                                "required_documents": {
+                                    "required": true
+                                }
+                            },
+                            "description": "object containing personalisation parameters - empty if no personalisation in the template"
+                        },
+                        "letter_contact_block": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": null,
+                            "description": "null for email templates"
+                        }
+                    }
+                },
+                {
+                    "title" : "letter",
+                    "type": "object",
+                    "description": "Get Letter template - response payload",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "example": "64415853-cb86-4cc4-b597-2aaa94ef8c39",
+                            "description": "required string - template ID"
+                        },
+                        "name": {
+                            "type": "string",
+                            "example": "Pigeon registration - appointment letter",
+                            "description": "required string - template name"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "sms",
+                                "email",
+                                "letter"
+                            ],
+                            "example": "letter",
+                            "description": "required string"
+                        },
+                        "created_at": {
+                            "type": "string",
+                            "example": "2024-05-10 10:30:31.142535Z",
+                            "description": "required string - date and time template created"
+                        },
+                        "updated_at": {
+                            "type": "string",
+                            "example": "2024-08-25 13:00:09.123234Z",
+                            "nullable": true,
+                            "description": "date and time template last updated or null"
+                        },
+                        "version": {
+                            "type": "integer",
+                            "example": 3
+                        },
+                        "created_by": {
+                            "type": "string",
+                            "example": "charlie.smith@pigeons.gov.uk",
+                            "description": "required string"
+                        },
+                        "body": {
+                            "type": "string",
+                            "example": "Dear ((first_name))\r\n\r\nYour pigeon registration appointment is scheduled for ((appointment_date)).\r\n\r\nPlease bring:\r\n\n\n((required_documents))\r\n\r\nYours,\r\nPigeon Affairs Bureau",
+                            "description": "required string - body of notification"
+                        },
+                        "subject": {
+                            "type": "string",
+                            "example": "Your upcoming pigeon registration appointment",
+                            "description": "required string for letter templates - letter heading"
+                        },
+                        "postage": {
+                            "type": "string",
+                            "enum": [
+                                "first",
+                                "second",
+                                "economy",
+                                "europe",
+                                "rest-of-world",
+                                null
+                            ],
+                            "nullable": true,
+                            "example": "second",
+                            "description": "required string for letter templates - default postage"
+                        },
+                        "personalisation": {
+                            "type": "object",
+                            "example": {
+                                "appointment_date": {
+                                    "required": true
+                                },
+                                "first_name": {
+                                    "required": true
+                                },
+                                "required_documents": {
+                                    "required": true
+                                }
+                            },
+                            "description": "object containing personalisation parameters - empty if no personalisation in the template"
+                        },
+                        "letter_contact_block": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": "Pigeons Affairs Bureau\n10 Whitechapel High Street\nLondon\nE1 8EF",
+                            "description": "optional string for letter templates - sender address"
+                        }
                     }
                 }
+            ]
             },
             "TemplatePreviewResponse": {
                 "type": "object",

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -1545,7 +1545,82 @@
                     "templates": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/TemplateResponse"
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "required string - template ID"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "required string - template name"
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "sms",
+                                        "email",
+                                        "letter"
+                                    ],
+                                    "description": "required string"
+                                },
+                                "created_at": {
+                                    "type": "string",
+                                    "description": "required string - date and time template created"
+                                },
+                                "updated_at": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "date and time template last updated or null"
+                                },
+                                "version": {
+                                    "type": "integer",
+                                    "description": "required integer"
+                                },
+                                "created_by": {
+                                    "type": "string",
+                                    "description": "required string"
+                                },
+                                "body": {
+                                    "type": "string",
+                                    "description": "required string - body of notification"
+                                },
+                                "subject": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "required string for emails and letters, nul for SMS"
+                                },
+                                "postage": {
+                                    "type": "string",
+                                    "enum": [
+                                        "first",
+                                        "second",
+                                        "economy",
+                                        "europe",
+                                        "rest-of-world",
+                                        null
+                                    ],
+                                    "nullable": true,
+                                    "description": "required string for letter, null for other template types"
+                                },
+                                "personalisation": {
+                                    "type": "object",
+                                    "example": {
+                                        "date": {
+                                            "required": true
+                                        },
+                                        "firstname": {
+                                            "required": true
+                                        }
+                                    },
+                                    "description": "object containing personalisation parameters - empty if no personalisation in the template"
+                                },
+                                "letter_contact_block": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "optional string for letters, null for other template types"
+                                }
+                            }
                         }
                     }
                 }

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -26,16 +26,16 @@
                                 "type": "string",
                                 "example": "Amala"
                             },
-                            "application_date": {
+                            "appointment_date": {
                                 "type": "string",
-                                "example": "2018-01-01"
+                                "example": "1 January 2018 at 1:00PM"
                             }
                         }
                     },
                     "reference": {
                         "type": "string",
                         "description": "You can leave out this argument if you do not have a reference. An identifier you can create if necessary. This reference identifies a single notification or a batch of notifications. It must not contain any personal information such as name or postal address.",
-                        "example": "STRING"
+                        "example": "your reference"
                     },
                     "sms_sender_id": {
                         "type": "string",
@@ -710,7 +710,7 @@
                     },
                     "reference": {
                         "type": "string",
-                        "example": "STRING"
+                        "example": "your reference"
                     },
                     "scheduled_for": {
                         "type": "string",
@@ -722,11 +722,11 @@
                         "properties": {
                             "body": {
                                 "type": "string",
-                                "example": "MESSAGE TEXT"
+                                "example": "Hi Amala, your appointment is on 1 January 2018 at 1:00PM"
                             },
                             "from_number": {
                                 "type": "string",
-                                "example": "SENDER"
+                                "example": "GOVUK"
                             }
                         }
                     },
@@ -743,11 +743,11 @@
                             },
                             "version": {
                                 "type": "number",
-                                "example": 1
+                                "example": 3
                             },
                             "uri": {
                                 "type": "string",
-                                "example": "https://api.notifications.service.gov.uk/v2/template/ceb50d92-100d-4b8b-b559-14fa3b091cd"
+                                "example": "https://api.notifications.service.gov.uk/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a"
                             }
                         }
                     }
@@ -1053,20 +1053,17 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
-                                    "example": "ValidationError",
                                     "description": "Error type"
                                 },
                                 "message": {
                                     "type": "string",
-                                    "example": "X is a required property",
                                     "description": "Error message"
                                 }
                             }
                         }
                     },
                     "status_code": {
-                        "type": "integer",
-                        "example": 400
+                        "type": "integer"
                     }
                 }
             },
@@ -1246,7 +1243,7 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
-                                    "example": "AuthError",
+                                    "example": "BadRequestErrorr",
                                     "description": "Error type"
                                 },
                                 "message": {

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -279,15 +279,19 @@
                 "properties": {
                     "personalisation": {
                         "type": "object",
-                        "description": "You can leave out this argument if a template does not have any placeholder fields for personalised information.<br/>If a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a dictionary with key value pairs. For example:",
+                        "description": "The keys in the personalisation argument must match the placeholder fields in the actual template. The API will ignore any extra keys in the personalisation argument.",
                         "properties": {
-                            "firstname": {
+                            "first_name": {
                                 "type": "string",
                                 "example": "Amala"
                             },
-                            "date": {
+                            "appointment_date": {
                                 "type": "string",
-                                "example": "19/08/2024"
+                                "example": "1 January 2018 at 1:00pm"
+                            },
+                            "required_documents":  {
+                                "type": "array",
+                                "example": ["passport", "utility bill", "other id"] 
                             }
                         }
                     }
@@ -1905,11 +1909,12 @@
             },
             "TemplatePreviewResponse": {
                 "type": "object",
-                "description": "If the request is successful, the response body is json and the status code is 200",
+                "description": "If the request is successful, the response body is `json` and the status code is `200`",
                 "properties": {
                     "id": {
                         "type": "string",
-                        "example": "b7a59abd-0ab2-4538-b619-8da9f9089e08"
+                        "example": "740e5834-3a29-46b4-9a6f-16142fde533a",
+                        "description": "required string - notification ID"
                     },
                     "type": {
                         "type": "string",
@@ -1918,28 +1923,29 @@
                             "email",
                             "letter"
                         ],
-                        "example": "sms",
+                        "example": "email",
                         "description": "required string"
                     },
                     "version": {
                         "type": "integer",
-                        "example": 2
+                        "example": 3,
+                        "description": "required string - version of template"
                     },
                     "body": {
                         "type": "string",
-                        "example": "Hi Amala, We have received your letter dated 19/08/2024.  No further action is required.",
-                        "description": "required string - body of notification"
+                        "example": "Dear Amala\r\n\r\nYour pigeon registration appointment is scheduled for 1 January 2018 at 1:00PM.\r\n\r\n Here is a link to your invitation document:\r\n\n\n* passport\n* utility bill\n* other id\r\n\r\nPlease bring the invite with you to the appointment.\r\n\r\nYours,\r\nPigeon Affairs Bureau",
+                        "description": "required string - Unformatted content of the notification"
                     },
                     "html": {
                         "type": "string",
                         "nullable": true,
-                        "example": null,
-                        "description": "html representation of the notification to be sent - null for sms"
+                        "example": "<p style=\"Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;\">Dear Amala</p> ... [snippet truncated for readability]",
+                        "description": "required string for emails, empty for SMS and letters. - body of notification"
                     },
                     "subject": {
                         "type": "string",
                         "nullable": true,
-                        "example": null,
+                        "example": "Your upcoming pigeon registration appointment",
                         "description": "required string for email - subject of email, otherwise null"
                     },
                     "postage": {
@@ -2060,7 +2066,7 @@
             },
             "TemplatePreviewRequestError": {
                 "type": "object",
-                "description": "Bad request error response",
+                "description": "Bad request. Check the `message` in the response to find out why your request failed. In addition to the endpoint specific errors shown in the examples, you may also encounter various schema validation errors, for example when you forget to pass in an argument, or pass in an argument of a wrong type. You can find a list of these errors at https://docs.notifications.service.gov.uk/rest-api.html#general-errors.",
                 "properties": {
                     "errors": {
                         "type": "array",
@@ -2069,13 +2075,11 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
-                                    "example": "BadRequestError",
-                                    "description": "Error type"
+                                    "example": "BadRequestError"
                                 },
                                 "message": {
                                     "type": "string",
-                                    "example": "Missing personalisation: [PERSONALISATION FIELD]",
-                                    "description": "Error message"
+                                    "example": "Missing personalisation: [PERSONALISATION FIELD]"
                                 }
                             }
                         }
@@ -2141,7 +2145,7 @@
             },
             "AuthError": {
                 "type": "object",
-                "description": "Auth error response",
+                "description": "Auth error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors.",
                 "properties": {
                     "errors": {
                         "type": "array",
@@ -2150,13 +2154,11 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
-                                    "example": "BadRequestError",
-                                    "description": "Error type"
+                                    "example": "BadRequestError"
                                 },
                                 "message": {
                                     "type": "string",
-                                    "example": "Error: Your system clock must be accurate to within 30 seconds",
-                                    "description": "Error string"
+                                    "example": "Error: Your system clock must be accurate to within 30 seconds"
                                 }
                             }
                         }
@@ -2169,7 +2171,7 @@
             },
             "LimitError": {
                 "type": "object",
-                "description": "Rate or service limit error response",
+                "description": "Rate or service limit error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors.",
                 "properties": {
                     "errors": {
                         "type": "array",
@@ -2178,13 +2180,11 @@
                             "properties": {
                                 "error": {
                                     "type": "string",
-                                    "example": "TooManyRequestsError",
-                                    "description": "Error type"
+                                    "example": "TooManyRequestsError"
                                 },
                                 "message": {
                                     "type": "string",
-                                    "example": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds",
-                                    "description": "Error string"
+                                    "example": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"
                                 }
                             }
                         }
@@ -2197,7 +2197,7 @@
             },
             "ServerError": {
                 "type": "array",
-                "description": "Rate or service limit error response",
+                "description": "Internal server error. Check the `message` in the response to find out why your request failed. For more examples please see https://docs.notifications.service.gov.uk/rest-api.html#general-errors.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -2207,8 +2207,7 @@
                         },
                         "message": {
                             "type": "string",
-                            "example": "Internal server error",
-                            "description": "Notify was unable to process the request, resend your notification."
+                            "example": "Internal server error"
                         }
                     }
                 }


### PR DESCRIPTION
This PR is best reviewed commit by commit.

This PR updates the OpenAPI spec to be more closely aligned with the REST API document.  Changes include:

* Updating example endpoint parameter and response values to be the same (or similar to) those used in the REST API doc.
* Updating the error response examples to include endpoint specific errors identified by @rparke 
* Added the returned letter callback data structure 
* Updating the x-logo property used by redocly to use the GOV.UK logo with the updated crown.

To view the OpenAPI spec in HTML format use the redocly docker image and the following command (from the openapi directory):  `docker run --rm -v $PWD:/spec redocly/cli lint publicapi_spec.json`