### PR TITLE
Add alphanumeric validation rule for letter addresses

### DIFF
--- a/source/documentation/error_tables/_send_a_letter.md
+++ b/source/documentation/error_tables/_send_a_letter.md
@@ -1,5 +1,6 @@
 **ValidationError (status code 400)**|
 `personalisation address_line_1 is a required property`|Ensure that your template has a field for the first line of the address, check [personalisation](#personalisation-required) for more information.|
+`The first 2 lines of the address must include alphanumeric characters`|Ensure that lines 1 and 2 both contain at least one alphanumeric character.|
 `Must be a real UK postcode`|Ensure that the value for the last line of the address is a real UK postcode.|
 `Must be a real address`|Provide a real recipient address. We do not accept letters for "no fixed abode" addresses, as those cannot be delivered.|
 `Last line of address must be a real UK postcode or another country`|Ensure that the value for the last line of the address is a real UK postcode or the name of a country outside the UK.|

--- a/source/documentation/error_tables/ruby/_send_a_letter.md
+++ b/source/documentation/error_tables/ruby/_send_a_letter.md
@@ -1,5 +1,6 @@
 **BadRequestError (status code 400)**|
 `ValidationError: personalisation address_line_1 is a required property`|Ensure that your template has a field for the first line of the address, check [personalisation](#personalisation-required) for more information.|
+`ValidationError: The first 2 lines of the address must both include at least one alphanumeric character`|Ensure that the first 2 lines of the address contain at least one alphanumeric character.|
 `ValidationError: Must be a real UK postcode`|Ensure that the value for the last line of the address is a real UK postcode.|
 `ValidationError: Must be a real address`|Provide a real recipient address. We do not accept letters for "no fixed abode" addresses, as those cannot be delivered.|
 `ValidationError: Last line of address must be a real UK postcode or another country`|Ensure that the value for the last line of the address is a real UK postcode or the name of a country outside the UK.|

--- a/source/java.html.md.erb
+++ b/source/java.html.md.erb
@@ -545,6 +545,8 @@ The personalisation argument always contains the following parameters for the le
 
 The address must have at least 3 lines.
 
+The first 2 lines of the address must include alphanumeric characters.
+
 The last line needs to be a real UK postcode or the name of a country outside the UK.
 
 Notify checks for international addresses and will automatically charge you the correct postage.
@@ -555,8 +557,8 @@ Any other placeholder fields included in the letter template also count as requi
 
 ```java
 Map<String, Object> personalisation = new HashMap<>();
-personalisation.put("address_line_1", "The Occupier"); // mandatory address field
-personalisation.put("address_line_2", "Flat 2"); // mandatory address field
+personalisation.put("address_line_1", "The Occupier"); // mandatory address field, must contain at least one alphanumeric character
+personalisation.put("address_line_2", "Flat 2"); // mandatory address field, must contain at least one alphanumeric character
 personalisation.put("address_line_3", "SW14 6BH"); // mandatory address field, must be a real UK postcode
 personalisation.put("first_name", "Amala"); // field from template
 personalisation.put("application_date", "2018-01-01"); // field from template

--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -627,6 +627,8 @@ The personalisation argument always contains the following parameters for the le
 
 The address must have at least 3 lines.
 
+The first 2 lines of the address must include alphanumeric characters.
+
 The last line needs to be a real UK postcode or the name of a country outside the UK.
 
 Notify checks for international addresses and will automatically charge you the correct postage.

--- a/source/node.html.md.erb
+++ b/source/node.html.md.erb
@@ -637,6 +637,8 @@ The personalisation argument always contains the following parameters for the le
 
 The address must have at least 3 lines.
 
+The first 2 lines of the address must include alphanumeric characters.
+
 The last line needs to be a real UK postcode or the name of a country outside the UK.
 
 Notify checks for international addresses and will automatically charge you the correct postage.
@@ -648,8 +650,8 @@ Any other placeholder fields included in the letter template also count as requi
 ```javascript
 {
   personalisation: {
-    "address_line_1": "Amala Bird", // required string
-    "address_line_2": "123 High Street", // required string
+    "address_line_1": "Amala Bird", // required string, must contain at least one alphanumeric character
+    "address_line_2": "123 High Street", // required string, must contain at least one alphanumeric character
     "address_line_3": "Richmond upon Thames", // required string
     "address_line_4": "Middlesex",
     "address_line_5": "SW14 6BF",  // last line of address you include must be a postcode or a country name  outside the UK

--- a/source/php.html.md.erb
+++ b/source/php.html.md.erb
@@ -592,6 +592,8 @@ The personalisation argument always contains the following parameters for the le
 
 The address must have at least 3 lines.
 
+The first 2 lines of the address must include alphanumeric characters.
+
 The last line needs to be a real UK postcode or the name of a country outside the UK.
 
 Notify checks for international addresses and will automatically charge you the correct postage.

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -568,6 +568,8 @@ The personalisation argument always contains the following parameters for the le
 
 The address must have at least 3 lines.
 
+The first 2 lines of the address must include alphanumeric characters.
+
 The last line needs to be a real UK postcode or the name of a country outside the UK.
 
 Notify checks for international addresses and will automatically charge you the correct postage.
@@ -578,8 +580,8 @@ Any other placeholder fields included in the letter template also count as requi
 
 ```python
 personalisation={
-  "address_line_1": "Amala Bird",  # required string
-  "address_line_2": "123 High Street",  # required string
+  "address_line_1": "Amala Bird",  # required string, must contain at least one alphanumeric character
+  "address_line_2": "123 High Street",  # required string, must contain at least one alphanumeric character
   "address_line_3": "Richmond upon Thames",  # required string
   "address_line_4": "Middlesex",
   "address_line_5": "SW14 6BF",  # last line of address you include must be a postcode or a country name  outside the UK

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -604,6 +604,8 @@ The personalisation argument always contains the following parameters for the le
 
 The address must have at least 3 lines.
 
+The first 2 lines of the address must include alphanumeric characters.
+
 The last line needs to be a real UK postcode or the name of a country outside the UK.
 
 Notify checks for international addresses and will automatically charge you the correct postage.
@@ -614,8 +616,8 @@ Any other placeholder fields included in the letter template also count as requi
 
 ```javascript
 "personalisation": {
-  "address_line_1": "Amala Bird",  // required string
-  "address_line_2": "123 High Street",  // required string
+  "address_line_1": "Amala Bird",  // required string, must contain at least one alphanumeric character
+  "address_line_2": "123 High Street",  // required string, must contain at least one alphanumeric character
   "address_line_3": "Richmond upon Thames",  // required string
   "address_line_4": "Middlesex",
   "address_line_5": "SW14 6BF",  // last line of address you include must be a postcode or a country name  outside the UK

--- a/source/ruby.html.md.erb
+++ b/source/ruby.html.md.erb
@@ -544,6 +544,8 @@ The personalisation argument always contains the following parameters for the le
 
 The address must have at least 3 lines.
 
+The first 2 lines of the address must include alphanumeric characters.
+
 The last line needs to be a real UK postcode or the name of a country outside the UK.
 
 Notify checks for international addresses and will automatically charge you the correct postage.


### PR DESCRIPTION
DVLA’s Print Hub introduced new address validation rules requiring that the first and second lines of a letter address each contain at least one alphanumeric character. This commit updates the documentation to reflect these changes for seand a letter. [Card](https://trello.com/c/ryRs3khh/1687-update-tech-docs-for-address-line-1-and-2-validation) for more details.