### PR TITLE
Update OpenAPI spec with additional letter specific validation error relating to DVLA address validation change.

### DIFF
--- a/openapi/POST_notification_letter.json
+++ b/openapi/POST_notification_letter.json
@@ -95,6 +95,15 @@
                                     "status_code": 400
                                 }
                             },
+                            "First two lines must include an alphanumeric character": {
+                                "value": {
+                                    "errors": [{
+                                        "error": "ValidationError",
+                                        "message": "The first 2 lines of the address must both include at least one alphanumeric character"
+                                    }],
+                                    "status_code": 400
+                                }
+                            },
                             "Must be a real UK postcode": {
                                 "value": {
                                     "errors": [{

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -163,15 +163,17 @@
                     },
                     "personalisation": {
                         "type": "object",
-                        "description": "The personalisation argument always contains the following parameters for the letter recipient’s address:\n\n**The address must have at least 3 lines.**\n\nThe last line needs to be a real UK postcode or the name of a country outside the UK.\n\nNotify checks for international addresses and will automatically charge you the correct postage.\n\nThe `postcode` personalisation argument has been replaced. If your template still uses `postcode`, Notify will treat it as the last line of the address.\n\nAny other placeholder fields included in the letter template also count as required parameters. You need to provide their values in a dictionary with key value pairs. For example:",
+                        "description": "The personalisation argument always contains the following parameters for the letter recipient’s address:\n\n**The address must have at least 3 lines.**\n\nThe first 2 lines of the address must include alphanumeric characters.\n\nThe last line needs to be a real UK postcode or the name of a country outside the UK.\n\nNotify checks for international addresses and will automatically charge you the correct postage.\n\nThe `postcode` personalisation argument has been replaced. If your template still uses `postcode`, Notify will treat it as the last line of the address.\n\nAny other placeholder fields included in the letter template also count as required parameters. You need to provide their values in a dictionary with key value pairs. For example:",
                         "properties": {
                             "address_line_1": {
                                 "type": "string",
-                                "example": "Amala Bird"
+                                "example": "Amala Bird",
+                                "description": "must contain at least one alphanumeric character"
                             },
                             "address_line_2": {
                                 "type": "string",
-                                "example": "123 High Street"
+                                "example": "123 High Street",
+                                "description": "must contain at least one alphanumeric character"
                             },
                             "address_line_3": {
                                 "type": "string",


### PR DESCRIPTION
This PR updates the OpenAPI spec, and specifically the "send a letter" specification and error response examples.

This change updates the OpenAPI spec to document the line_1 and line_2 address validation changes made by the DVLA.  This PR brings the OpenAPI spec in line with the API client documentation which was updated in https://github.com/alphagov/notifications-tech-docs/pull/321

DVLA’s Print Hub introduced new address validation rules requiring that the first and second lines of a letter address each contain at least one alphanumeric character. This commit updates the documentation to reflect these changes for seand a letter. [Card](https://trello.com/c/ryRs3khh/1687-update-tech-docs-for-address-line-1-and-2-validation) for more details.

To view the OpenAPI spec in HTML format use the redocly docker image and the following command (from the openapi directory): docker run --rm -v $PWD:/spec redocly/cli lint publicapi_spec.json