### PR TITLE
Update 'validation-failed' description for precompiled letter statuses.

### DIFF
--- a/source/java.html.md.erb
+++ b/source/java.html.md.erb
@@ -875,7 +875,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 

--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -990,7 +990,7 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 

--- a/source/node.html.md.erb
+++ b/source/node.html.md.erb
@@ -1026,7 +1026,7 @@ If the request is not successful, the promise fails with an `err`. To learn more
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 

--- a/source/php.html.md.erb
+++ b/source/php.html.md.erb
@@ -993,7 +993,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -1019,7 +1019,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -1004,7 +1004,7 @@ If the request is not successful, the API returns `json` containing the relevant
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 

--- a/source/ruby.html.md.erb
+++ b/source/ruby.html.md.erb
@@ -894,7 +894,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 


### PR DESCRIPTION
Adding “Validation failed because the last line of the address is not a UK postcode or another country,” as it can also be the reason why validation failed.

Added to all clients and REST docs.

**Before**
<img width="789" height="82" alt="Screenshot 2026-04-30 at 13 25 03" src="https://github.com/user-attachments/assets/5c23ee23-a959-4fc5-a2c6-b2a3dc0db017" />


**After**
<img width="787" height="120" alt="Screenshot 2026-04-30 at 13 19 56" src="https://github.com/user-attachments/assets/cc4f5887-aa32-411d-a4a8-011c70ebc62f" />
