### PR TITLE
Refactor notification status description section into a single file 

### DIFF
--- a/source/documentation/notification_statuses/_notification_statuses.md
+++ b/source/documentation/notification_statuses/_notification_statuses.md
@@ -1,0 +1,46 @@
+### Email status descriptions
+
+|Status|Description|
+|:---|:---|
+|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
+|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
+|#`delivered`|The message was successfully delivered.|
+|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
+|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
+|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
+
+### Text message status descriptions
+
+|Status|Description|
+|:---|:---|
+|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
+|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
+|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
+|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
+|#`delivered`|The message was successfully delivered.|
+|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
+|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
+|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
+
+### Letter status descriptions
+
+|Status|Description|
+|:---|:---|
+|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
+|#`received`|The provider has printed and dispatched the letter.|
+|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
+|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
+
+### Precompiled letter status descriptions
+
+|Status|Description|
+|:---|:---|
+|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
+|#`received`|The provider has printed and dispatched the letter.|
+|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
+|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
+|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
+|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
+|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|

--- a/source/java.html.md.erb
+++ b/source/java.html.md.erb
@@ -832,52 +832,8 @@ If the request is not successful, the client returns an error. To learn more abo
 |:---|:---|
 <%= partial 'documentation/error_tables/get_the_data_for_multiple_messages' %>
 
-### Email status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
-
-### Text message status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
-
-### Letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
-### Precompiled letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
+<!-- Notification status descriptions: -->
+<%= partial 'documentation/notification_statuses/notification_statuses' %>
 
 ### Get a PDF for a letter notification
 

--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -947,52 +947,8 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |:---|:---|
 <%= partial 'documentation/error_tables/get_the_data_for_multiple_messages' %>
 
-### Email status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
-
-### Text message status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|#`delivered`|The message was successfully delivered. If a recipient blocks your sender ID or mobile number, your message will still show as delivered.|
-|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
-
-### Letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
-### Precompiled letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
+<!-- Notification status descriptions: -->
+<%= partial 'documentation/notification_statuses/notification_statuses' %>
 
 ### Get a PDF for a letter notification
 

--- a/source/node.html.md.erb
+++ b/source/node.html.md.erb
@@ -982,54 +982,8 @@ If the request is not successful, the promise fails with an `err`. To learn more
 |:---|:---|
 <%= partial 'documentation/error_tables/get_the_data_for_multiple_messages' %>
 
-
-### Email status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
-
-### Text message status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|#`delivered`|The message was successfully delivered. If a recipient blocks your sender ID or mobile number, your message will still show as delivered.|
-|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
-
-### Letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
-### Precompiled letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
+<!-- Notification status descriptions: -->
+<%= partial 'documentation/notification_statuses/notification_statuses' %>
 
 ### Get a PDF for a letter notification
 

--- a/source/php.html.md.erb
+++ b/source/php.html.md.erb
@@ -949,53 +949,8 @@ If the request is not successful, the client returns an error. To learn more abo
 |:---|:---|
 <%= partial 'documentation/error_tables/get_the_data_for_multiple_messages' %>
 
-
-### Email status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
-
-### Text message status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|#`delivered`|The message was successfully delivered. If a recipient blocks your sender ID or mobile number, your message will still show as delivered.|
-|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
-
-### Letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
-### Precompiled letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
+<!-- Notification status descriptions: -->
+<%= partial 'documentation/notification_statuses/notification_statuses' %>
 
 ### Get a PDF for a letter notification
 

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -976,52 +976,8 @@ If the request is not successful, the client returns an error. To learn more abo
 |:---|:---|
 <%= partial 'documentation/error_tables/get_the_data_for_multiple_messages' %>
 
-### Email status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
-
-### Text message status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|#`delivered`|The message was successfully delivered. If a recipient blocks your sender ID or mobile number, your message will still show as delivered.|
-|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
-
-### Letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
-### Precompiled letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
+<!-- Notification status descriptions: -->
+<%= partial 'documentation/notification_statuses/notification_statuses' %>
 
 ### Get a PDF for a letter notification
 

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -960,54 +960,9 @@ If the request is not successful, the API returns `json` containing the relevant
 |Error message|How to fix|
 |:---|:---|
 <%= partial 'documentation/error_tables/get_the_data_for_multiple_messages' %>
-### Email status descriptions
 
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
-
-### Text message status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|#`delivered`|The message was successfully delivered. If a recipient blocks your sender ID or mobile number, your message will still show as delivered.|
-|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
-
-
-### Letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
-### Precompiled letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
+<!-- Notification status descriptions: -->
+<%= partial 'documentation/notification_statuses/notification_statuses' %>
 
 ### Get a PDF for a letter notification
 

--- a/source/ruby.html.md.erb
+++ b/source/ruby.html.md.erb
@@ -851,53 +851,8 @@ If the request is not successful, the client returns an error. To learn more abo
 |:---|:---|
 <%= partial 'documentation/error_tables/ruby/get_the_data_for_multiple_messages' %>
 
-### Email status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`delivered`|The message was successfully delivered.|
-|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
-
-### Text message status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|#`delivered`|The message was successfully delivered. If a recipient blocks your sender ID or mobile number, your message will still show as delivered.|
-|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
-
-### Letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
-### Precompiled letter status descriptions
-
-|Status|Description|
-|:---|:---|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`received`|The provider has printed and dispatched the letter.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|#`validation-failed`|Content in the precompiled letter file failed validation. This can happen if:<ul><li>content is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.</li><li>the last line of the address is not a UK postcode or another country</li></ul>|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
-|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
-
+<!-- Notification status descriptions: -->
+<%= partial 'documentation/notification_statuses/notification_statuses' %>
 
 ### Get a PDF for a letter notification
 


### PR DESCRIPTION
So when updating the status descriptions, we can do it once, instead of doing it seven times.

This will save us time and help us avoid mistakes / differences between the docs.
