### PR TITLE
Update technical failure error message

### DIFF
--- a/source/java.html.md.erb
+++ b/source/java.html.md.erb
@@ -863,7 +863,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
@@ -876,7 +876,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Get a PDF for a letter notification

--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -978,7 +978,7 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
@@ -991,7 +991,7 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Get a PDF for a letter notification

--- a/source/node.html.md.erb
+++ b/source/node.html.md.erb
@@ -1014,7 +1014,7 @@ If the request is not successful, the promise fails with an `err`. To learn more
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
@@ -1027,7 +1027,7 @@ If the request is not successful, the promise fails with an `err`. To learn more
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 

--- a/source/php.html.md.erb
+++ b/source/php.html.md.erb
@@ -981,7 +981,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
@@ -994,7 +994,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Get a PDF for a letter notification

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -1007,7 +1007,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
@@ -1020,7 +1020,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Get a PDF for a letter notification

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -992,7 +992,7 @@ If the request is not successful, the API returns `json` containing the relevant
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
@@ -1005,7 +1005,7 @@ If the request is not successful, the API returns `json` containing the relevant
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 

--- a/source/ruby.html.md.erb
+++ b/source/ruby.html.md.erb
@@ -882,7 +882,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
@@ -895,7 +895,7 @@ If the request is not successful, the client returns an error. To learn more abo
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`technical-failure`|Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 


### PR DESCRIPTION
When letters are rejected by DVLA we update notification status to technical-failure. During incident we found inconsistency between the API and UI and may cause services to try and resend their letter. This PR updates the error message description for tech docs.
More details on this [card](https://trello.com/c/Y7MfglOL/1733-review-and-update-technical-failure-advise-in-ui-and-api).

API docs and client libraries:
<img width="1924" height="806" alt="image" src="https://github.com/user-attachments/assets/dbdccb38-9025-4a53-bf38-aeacdac9af7c" />


API docs and client libraries (precompiled letter):
<img width="1924" height="1210" alt="image" src="https://github.com/user-attachments/assets/7ba71a24-9228-49a0-bc90-bea3125adae2" />
