### PR TITLE
Sanitise placeholder content [Rest API]

### DIFF
--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -428,7 +428,7 @@ The response will include the content that we've sanitised:
 ```
 
 ##### 2. Use a backslash
-Add this in front of [individual Markdwon characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them.
+Add this in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them.
 The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 #### Error codes

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -2,7 +2,7 @@
 title: REST API documentation
 parent: https://www.notifications.service.gov.uk/documentation
 ---
-# REST API documentation
+# REST API documentation 
 
 This documentation is for developers interested in using the GOV.UK Notify API to send emails, text messages or letters.
 
@@ -369,11 +369,67 @@ Hello ((name))
  <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
 </pre>
 
-
+#### Sanitise placeholder content
 We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content.
-You can use a backslash to escape [individual characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape).
-The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
+To escape all Markdown characters, and remove any URL links you can:
+
+##### 1. Tell us which personalisation to sanitise
+When sending emails via API, pass in the `sanitise_content_for` argument, and choose which personalisation you want to sanitise.
+
+For all personalisation you tell us to sanitise, we will:
+
+* escape all Markdown characters
+* remove any url links from the text
+* tell you what content we’ve sanitised
+
+For example, when you make the following API call:
+
+```javascript
+# endpoint
+POST /v2/notifications/email
+
+## Request body
+{
+  "email address": "amalaexample@example.com"
+  "template_id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3"
+  "personalisation": {
+    "name": "user name from a form"
+    "sign_up_link": "link generated in your system"
+  }, 
+  "sanitise_content_for": ["name"]
+}
+```
+
+Notify will sanitise the specificed placeholders, like this:
+
+```javascript
+# malicious markdown:
+name = "Anne Example, now [click this evil link](https://evil.link)"
+
+# gets sanitised to:
+"Anne Example, now \[click this evil link\]\(\)"
+
+# email will appear as:
+Anne Example, now [click this evil link]()
+```
+
+The response will include the content that we've sanitised:
+
+```javascript
+{
+  "sanitised_content": {
+    "name": {
+      "unsanitised": "Anne Example, now [click this evil link](https://evil.link)"
+      "sanitised": "Anne Example, now \[click this evil link\]\(\)\"
+    }
+  }
+}
+```
+
+##### 2. Use a backslash
+Add this in front of [individual Markdwon characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them.
+The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
 
 #### Error codes
 


### PR DESCRIPTION
Added content on how to sanitise placeholder to protect from malicious content injection.

Will need a review from a dev for the examples added as part of this content. 

Visuals
<img width="786" height="441" alt="Screenshot 2026-05-14 at 13 51 32" src="https://github.com/user-attachments/assets/5baf472a-1a7d-4a8a-a937-53dabc327c26" />
<img width="798" height="774" alt="Screenshot 2026-05-14 at 13 51 40" src="https://github.com/user-attachments/assets/26834a98-3b11-4e57-b70a-abe6f570588a" />
<img width="813" height="501" alt="Screenshot 2026-05-14 at 13 51 49" src="https://github.com/user-attachments/assets/0d6b06ed-1418-4765-8c52-1acb89bbee0d" />

