### PR TITLE
Bump tech-docs gem to 6.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'govuk_tech_docs', '~> 6.0.1'
+gem 'govuk_tech_docs', '~> 6.2.1'
 gem 'mini_racer', '~> 0.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,14 +19,15 @@ GEM
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     base64 (0.3.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     chronic (0.10.2)
     chunky_png (1.4.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (2.8.1-arm64-darwin)
+    commonmarker (2.8.2-aarch64-linux)
+    commonmarker (2.8.2-arm64-darwin)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -39,7 +40,7 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     contracts (0.17.3)
     csv (3.3.5)
@@ -53,30 +54,33 @@ GEM
     execjs (2.10.1)
     fast_blank (1.0.1)
     fastimage (2.4.1)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
     google-protobuf (4.34.1-arm64-darwin)
       bigdecimal
       rake (~> 13.3)
-    govuk_tech_docs (6.0.1)
-      autoprefixer-rails (~> 10.2)
-      base64
-      bigdecimal
-      chronic (~> 0.10.2)
-      concurrent-ruby (= 1.3.4)
+    govuk_tech_docs (6.2.1)
+      autoprefixer-rails
+      chronic
+      concurrent-ruby
       csv
       haml (~> 6.0)
-      middleman (~> 4.6.1)
-      middleman-autoprefixer (~> 2.10)
-      middleman-compass (~> 4.0)
+      middleman
+      middleman-autoprefixer
+      middleman-compass
       middleman-livereload
       middleman-search-gds
-      middleman-sprockets (~> 4.0.0)
-      middleman-syntax (~> 3.6)
+      middleman-sprockets (= 4.0.0)
+      middleman-syntax
       mutex_m
       nokogiri
-      openapi3_parser (~> 0.10.1)
-      redcarpet (~> 3.6)
-      sassc-embedded (~> 1.78.0)
+      openapi3_parser
+      redcarpet
+      sassc-embedded
+      schmooze (~> 0.2.0)
       terser (~> 1.2.3)
     haml (6.4.0)
       temple (>= 0.8.2)
@@ -89,9 +93,10 @@ GEM
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.3)
+    json (2.19.5)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
+    libv8-node (18.16.0.0-aarch64-linux)
     libv8-node (18.16.0.0-arm64-darwin)
     listen (3.10.0)
       logger
@@ -102,9 +107,9 @@ GEM
     middleman (4.6.3)
       middleman-cli (= 4.6.3)
       middleman-core (= 4.6.3)
-    middleman-autoprefixer (2.10.0)
-      autoprefixer-rails (>= 9.1.4)
-      middleman-core (>= 3.3.3)
+    middleman-autoprefixer (3.0.0)
+      autoprefixer-rails (~> 10.0)
+      middleman-core (>= 4.0.0)
     middleman-cli (4.6.3)
       thor (>= 0.17.0, < 2)
     middleman-compass (4.0.1)
@@ -154,12 +159,14 @@ GEM
       rouge (~> 3.2)
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
-    minitest (6.0.3)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    multi_json (1.20.1)
+    multi_json (1.21.1)
     mutex_m (0.3.0)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     openapi3_parser (0.10.1)
       commonmarker (>= 1.0)
@@ -168,7 +175,7 @@ GEM
       padrino-support (= 0.16.1)
       tilt (>= 2.1, < 3)
     padrino-support (0.16.1)
-    parallel (2.0.1)
+    parallel (2.1.0)
     parslet (2.0.0)
     prism (1.9.0)
     public_suffix (7.0.5)
@@ -178,7 +185,7 @@ GEM
       rack (>= 3.0, < 3.2)
     rackup (2.3.1)
       rack (>= 3)
-    rake (13.4.1)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -186,12 +193,15 @@ GEM
     rexml (3.4.4)
     rouge (3.30.0)
     sass (3.4.25)
+    sass-embedded (1.99.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
     sass-embedded (1.99.0-arm64-darwin)
       google-protobuf (~> 4.31)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-embedded (1.78.0)
-      sass-embedded (~> 1.78)
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
+    schmooze (0.2.0)
     securerandom (0.4.1)
     servolux (0.13.0)
     sprockets (4.2.2)
@@ -213,11 +223,12 @@ GEM
     webrick (1.9.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   arm64-darwin-25
 
 DEPENDENCIES
-  govuk_tech_docs (~> 6.0.1)
+  govuk_tech_docs (~> 6.2.1)
   mini_racer (~> 0.8.0)
 
 BUNDLED WITH


### PR DESCRIPTION
Fixes comments text colour  in code blocks among other things

https://github.com/alphagov/tech-docs-gem/releases

Before
<img width="804" height="452" alt="Screenshot 2026-05-14 at 16 04 06" src="https://github.com/user-attachments/assets/3408170d-4ff7-42e2-941b-19eef24cc490" />


After
<img width="802" height="443" alt="Screenshot 2026-05-14 at 16 10 22" src="https://github.com/user-attachments/assets/f573b78c-a6f1-4e34-afe8-d2e508534a40" />
