### PR TITLE
[python] Improve guidance for sanitise_personalisation

### DIFF
--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -268,77 +268,10 @@ email_reply_to_id="ca4fdde7-2a67-4a6c-8393-62aa7245751f", # optional UUID string
 
 You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.
 
-#### Response
+##### sanitise_content_for (optional)
 
-If the request to the client is successful, the client returns a `dict`:
-
-```python
-{
-  "id": "201b576e-c09b-467b-9dfa-9c3b689ee730",  # required string - notification ID
-  "reference": "your reference",  # optional string - reference you provided when sending the message
-  "content": {
-    "subject": "Your upcoming pigeon registration appointment",  # required string - message subject
-    "body": "Dear Amala\r\n\r\nYour pigeon registration appointment is scheduled for 1 January 2018 at 1:00pm.\r\n\r\nPlease bring:\r\n\n\n* passport\n* utility bill\n* other id\r\n\r\nYours,\r\nPigeon Affairs Bureau",  # required string - message content
-    "from_email": "pigeon.affairs.bureau@notifications.service.gov.uk",  # required string - "FROM" email address, not a real inbox
-    "one_click_unsubscribe_url": "https://example.com/unsubscribe.html?opaque=123456789",  # optional string
-  },
-  "uri": "https://api.notifications.service.gov.uk/v2/notifications/201b576e-c09b-467b-9dfa-9c3b689ee730",  # required string
-  "template": {
-    "id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3",  # required string - template ID
-    "version": 1,  # required integer
-    "uri": "https://api.notifications.service.gov.uk/v2/template/9d751e0e-f929-4891-82a1-a3e1c3c18ee3"  # required string
-  }
-}
-```
-
-#### Error codes
-
-If the request is not successful, the client returns an error. To learn more about error structure, go to [Errors section](#errors).
-
-|Error message|How to fix|
-|:---|:---|
-<%= partial 'documentation/error_tables/send_an_email' %>
-
-#### Reducing the risk of malicious content injection in placeholders
-
-Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
-
-You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown.
-
-If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify.
-
-The malicious content could be:
-
-  * Markdown syntax intended to be rendered into HTML
-  * a plain text URL which would be rendered into a clickable phishing link
-
-An example of how malicious content can be injected into Notify personalisation:
-
-**Template in Notify**:
-
-```python
-Hello ((name))
-```
-
-**Personalisation**:
-
-```python
-{name: "Anne Example, now [click this evil link](https://malicious.link)"}
-```
-
-**Email will appear as**:
-
-<pre>
- <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
-</pre>
-
-#### Sanitise placeholder content
-We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content.
-
-To escape all Markdown characters, and remove any URLs you can:
-
-##### 1. Tell us which personalisation to sanitise
-When sending emails via API, pass in the `sanitise_content_for` argument, and choose which personalisation you want to sanitise.
+A list of personalisation keys you want Notify to sanitise.
+See also: [Reducing the risk of malicious content injection in placeholders for more information](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
 
 For all personalisation you tell us to sanitise, we will:
 
@@ -376,10 +309,81 @@ The `"sanitised_content"` field of `response` shows how Notify has sanitised the
   }
 }
 ```
+The field is empty if `sanitise_content_for` didn't change any personalisation.
 
-##### 2. Use a backslash
-Add this in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them.
-The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
+#### Response
+
+If the request to the client is successful, the client returns a `dict`:
+
+```python
+{
+  "id": "201b576e-c09b-467b-9dfa-9c3b689ee730",  # required string - notification ID
+  "reference": "your reference",  # optional string - reference you provided when sending the message
+  "content": {
+    "subject": "Your upcoming pigeon registration appointment",  # required string - message subject
+    "body": "Dear Amala\r\n\r\nYour pigeon registration appointment is scheduled for 1 January 2018 at 1:00pm.\r\n\r\nPlease bring:\r\n\n\n* passport\n* utility bill\n* other id\r\n\r\nYours,\r\nPigeon Affairs Bureau",  # required string - message content
+    "from_email": "pigeon.affairs.bureau@notifications.service.gov.uk",  # required string - "FROM" email address, not a real inbox
+    "one_click_unsubscribe_url": "https://example.com/unsubscribe.html?opaque=123456789",  # optional string
+  },
+  "uri": "https://api.notifications.service.gov.uk/v2/notifications/201b576e-c09b-467b-9dfa-9c3b689ee730",  # required string
+  "template": {
+    "id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3",  # required string - template ID
+    "version": 1,  # required integer
+    "uri": "https://api.notifications.service.gov.uk/v2/template/9d751e0e-f929-4891-82a1-a3e1c3c18ee3"  # required string
+},
+  "sanitised_content": {},
+}
+```
+
+#### Error codes
+
+If the request is not successful, the client returns an error. To learn more about error structure, go to [Errors section](#errors).
+
+|Error message|How to fix|
+|:---|:---|
+<%= partial 'documentation/error_tables/send_an_email' %>
+
+#### Reducing the risk of malicious content injection in placeholders
+
+Notify lets you [personalise messages](https://www.notifications.service.gov.uk/using-notify/personalisation) using placeholders.
+
+You can [format](https://www.notifications.service.gov.uk/using-notify/formatting) content or add links and urls into placeholders using Markdown.
+
+If you pass in information from untrusted sources (such as online forms) into your Notify template using personalisation, this may be used to add malicious content and links to notifications you send via Notify.
+
+The malicious content could be:
+
+  * Markdown syntax intended to be rendered into HTML
+  * a plain text URL which would be rendered into a clickable phishing link
+
+An example of how malicious content can be injected into Notify personalisation:
+
+Template in Notify:
+
+```python
+Hello ((name))
+```
+
+Personalisation:
+
+```python
+{name: "Anne Example, now [click this evil link](https://malicious.link)"}
+```
+
+Email will appear as:
+
+<pre>
+ <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
+</pre>
+
+##### Sanitise placeholder content
+We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content.
+
+To escape all Markdown characters, and remove any URLs you can:
+
+1. Tell us which personalisation to sanitise by passing in [sanitise_content_for argument](#sanitise-content-for-optional) when sending emails via API.
+
+2. Add a backslash in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them. The characters of most concern are those that could be used to add a link such as `[`, `]`, `(` or `)`.
 
 
 ### Send a file by email


### PR DESCRIPTION
- move guidance about sanitise_content_for to the args section of send_email_notification endpoint
- add sanitised_content to response example
- remove some bold and headers as not needed anymore