### PR TITLE
Fix argument name for `GET /v2/templates`

### DIFF
--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -1171,7 +1171,7 @@ GET /v2/templates
 
 #### Query parameters
 
-##### template_type (optional)
+##### type (optional)
 
 If you leave out this argument, the method returns all templates. Otherwise you can filter by:
 


### PR DESCRIPTION
It’s `type`, as defined here: https://github.com/alphagov/notifications-api/blob/7dcdcf4014413a5a8ec2876b4157250b3efdee13/app/v2/templates/templates_schemas.py#L10

I’ve checked all the clients and they – while calling the argument different names – always put it in the query string correctly.

So it’s just the REST API docs which need fixing