### PR TITLE
Harmonise docs for sanitise personalisation

### DIFF
--- a/source/node.html.md.erb
+++ b/source/node.html.md.erb
@@ -319,13 +319,48 @@ You can leave out this argument if your service only has one reply-to email addr
 
 ##### sanitiseContentFor (optional)
 
+An array of personalisation keys you want Notify to sanitise.
+
+See also: [Reducing the risk of malicious content injection in placeholders for more information](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
+For all personalisation you tell us to sanitise, we will:
+
+* escape all Markdown characters
+* remove any URLs from the text
+* tell you what content we’ve sanitised
+
+For example, when you make the following API call:
+
 ```javascript
 let options = {
-    sanitiseContentFor:["name"]
+    personalisation: {
+        name: "Anne Example, now [click this evil link](https://evil.link)",
+        sign_up_link: "link generated in your system"
+    },
+    sanitiseContentFor: ["name"],
 };
+
+notifyClient.sendEmail(templateId, emailAddress, options)
 ```
 
-An array of personalisation key strings to be sanitised. See [Sanitise placeholder content](#sanitise-placeholder-content) section
+Notify will sanitise the content of the `name` placeholder. In the email it will appear as:
+
+```text
+Anne Example, now [click this evil link]()
+```
+
+The `"sanitised_content"` field of `response` shows how Notify has sanitised the content:
+
+```javascript
+{
+  "name": {
+    "unsanitised": "Anne Example, now [click this evil link](https://evil.link)"
+    "sanitised": "Anne Example, now \[click this evil link\]\(\)\"
+  }
+}
+
+```
+The field is empty if `sanitiseContentFor` didn't change any personalisation.
 
 #### Response
 
@@ -346,9 +381,19 @@ If the request is successful, the promise resolves with a `response` `object`. F
         "id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3", // required string - template ID
         "version": 1, // required integer
         "uri": "https://api.notifications.service.gov.uk/v2/template/9d751e0e-f929-4891-82a1-a3e1c3c18ee3" // required string
-    }
+    },
+  "sanitised_content": {}
 };
 ```
+
+#### Error codes
+
+If the request is not successful, the promise fails with an `err`. To learn more about error structure, go to [Errors section](#errors).
+
+
+|Error message|How to fix|
+|:---|:---|
+<%= partial 'documentation/error_tables/send_an_email' %>
 
 #### Reducing the risk of malicious content injection in placeholders
 
@@ -365,95 +410,33 @@ The malicious content could be:
 
 An example of how malicious content can be injected into Notify personalisation:
 
-**Template in Notify**:
+Template in Notify:
 
 ```javascript
 Hello ((name))
 ```
 
-**Personalisation**:
+Personalisation:
 
 ```javascript
 {name: "Anne Example, now [click this evil link](https://malicious.link)"}
 ```
 
-**Email will appear as**:
+Email will appear as:
 
 <pre>
  <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
 </pre>
 
 
-#### Sanitise placeholder content
+##### Sanitise placeholder content
 We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content.
 
-To escape all Markdown characters, and remove any URL links you can:
+To escape all Markdown characters, and remove any URLs you can:
 
-##### 1. Tell us which personalisation to sanitise
-When sending emails via API, pass in the `sanitiseContentFor` argument, and choose which personalisation you want to sanitise.
+1. Tell us which personalisation to sanitise by using the [`sanitiseContentFor` argument](#sanitisecontentfor-optional) when sending emails via API.
 
-For all personalisation you tell us to sanitise, we will:
-
-* escape all Markdown characters
-* remove any url links from the text
-* tell you what content we’ve sanitised
-
-For example, when you make the following API call:
-
-```javascript
-# endpoint
-POST /v2/notifications/email
-
-## Request body
-{
-  "email address": "amalaexample@example.com"
-  "template_id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3"
-  "personalisation": {
-    "name": "user name from a form"
-    "sign_up_link": "link generated in your system"
-  }, 
-  "sanitiseContentFor": ["name"]
-}
-```
-
-Notify will sanitise the specificed placeholders, like this:
-
-```javascript
-# malicious markdown:
-name = "Anne Example, now [click this evil link](https://evil.link)"
-
-# gets sanitised to:
-"Anne Example, now \[click this evil link\]\(\)"
-
-# email will appear as:
-Anne Example, now [click this evil link]()
-```
-
-The response will include the content that we've sanitised:
-
-```javascript
-{
-  "sanitised_content": {
-    "name": {
-      "unsanitised": "Anne Example, now [click this evil link](https://evil.link)"
-      "sanitised": "Anne Example, now \[click this evil link\]\(\)\"
-    }
-  }
-}
-```
-
-##### 2. Use a backslash
-Add this in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them.
-The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
-
-#### Error codes
-
-If the request is not successful, the promise fails with an `err`. To learn more about error structure, go to [Errors section](#errors).
-
-
-|Error message|How to fix|
-|:---|:---|
-<%= partial 'documentation/error_tables/send_an_email' %>
+2. Add a backslash in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them. The characters of most concern are those that could be used to add a link such as `[`, `]`, `(` or `)`.
 
 
 ### Send a file by email

--- a/source/python.html.md.erb
+++ b/source/python.html.md.erb
@@ -283,13 +283,13 @@ For example, when you make the following API call:
 
 ```python
 response = notifications_client.send_email_notification(
-    email_address="amala@example.com",
+    email_address="anne.example@example.com",
     template_id="9d751e0e-f929-4891-82a1-a3e1c3c18ee3",
-    "personalisation": {
+    personalisation={
         "name": "Anne Example, now [click this evil link](https://evil.link)"
         "sign_up_link": "link generated in your system"
     },
-    "sanitise_content_for": ["name"]
+    sanitise_content_for=["name"]
 )
 ```
 
@@ -331,7 +331,7 @@ If the request to the client is successful, the client returns a `dict`:
     "version": 1,  # required integer
     "uri": "https://api.notifications.service.gov.uk/v2/template/9d751e0e-f929-4891-82a1-a3e1c3c18ee3"  # required string
 },
-  "sanitised_content": {},
+  "sanitised_content": {}
 }
 ```
 

--- a/source/rest-api.html.md.erb
+++ b/source/rest-api.html.md.erb
@@ -313,6 +313,55 @@ For example:
 
 You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.
 
+##### sanitise_content_for (optional)
+
+A list of personalisation keys you want Notify to sanitise.
+See also: [Reducing the risk of malicious content injection in placeholders for more information](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
+For all personalisation you tell us to sanitise, we will:
+
+* escape all Markdown characters
+* remove any URLs from the text
+* tell you what content we’ve sanitised
+
+For example, when you make an API call:
+
+```javascript
+// endpoint
+POST /v2/notifications/email
+
+// Request body
+{
+  "email_address": "anne.example@example.com",
+  "template_id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3",
+  "personalisation": {
+    "name": "Anne Example, now [click this evil link](https://evil.link)",
+    "sign_up_link": "link generated in your system"
+  },
+  "sanitise_content_for": ["name"]
+}
+```
+
+Notify will sanitise the content of the `name` placeholder. In the email it will appear as:
+
+```text
+Anne Example, now [click this evil link]()
+```
+
+The `"sanitised_content"` field of `response` shows how Notify has sanitised the content:
+
+```javascript
+{
+  "sanitised_content": {
+    "name": {
+      "unsanitised": "Anne Example, now [click this evil link](https://evil.link)"
+      "sanitised": "Anne Example, now \[click this evil link\]\(\)\"
+    }
+  }
+}
+```
+The field is empty if `sanitise_content_for` didn't change any personalisation.
+
 #### Response
 
 If the request is successful, the response body is `json` with a status code of `201`:
@@ -332,9 +381,19 @@ If the request is successful, the response body is `json` with a status code of 
     "id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3",  // required string - template ID
     "version": 1,  // required integer
     "uri": "https://api.notifications.service.gov.uk/v2/template/9d751e0e-f929-4891-82a1-a3e1c3c18ee3"  // required string
-  }
+  },
+  "sanitised_content": {}
 }
 ```
+
+#### Error codes
+
+If the request is not successful, the API returns `json` containing the relevant error code.
+To learn more about error structure, go to [Errors section](#errors).
+
+|Error message|How to fix|
+|:---|:---|
+<%= partial 'documentation/error_tables/send_an_email' %>
 
 #### Reducing the risk of malicious content injection in placeholders
 
@@ -351,94 +410,32 @@ The malicious content could be:
 
 An example of how malicious content can be injected into Notify personalisation:
 
-**Template in Notify**:
+Template in Notify:
 
 ```javascript
 Hello ((name))
 ```
 
-**Personalisation**:
+Personalisation:
 
 ```javascript
 {name: "Anne Example, now [click this evil link](https://malicious.link)"}
 ```
 
-**Email will appear as**:
+Email will appear as:
 
 <pre>
  <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
 </pre>
 
-#### Sanitise placeholder content
+##### Sanitise placeholder content
 We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content.
 
-To escape all Markdown characters, and remove any URL links you can:
+To escape all Markdown characters, and remove any URLs you can:
 
-##### 1. Tell us which personalisation to sanitise
-When sending emails via API, pass in the `sanitise_content_for` argument, and choose which personalisation you want to sanitise.
+1. Tell us which personalisation to sanitise by using the [`sanitise_content_for` argument](#sanitise-content-for-optional) when sending emails via API.
 
-For all personalisation you tell us to sanitise, we will:
-
-* escape all Markdown characters
-* remove any url links from the text
-* tell you what content we’ve sanitised
-
-For example, when you make the following API call:
-
-```javascript
-# endpoint
-POST /v2/notifications/email
-
-## Request body
-{
-  "email address": "amalaexample@example.com"
-  "template_id": "9d751e0e-f929-4891-82a1-a3e1c3c18ee3"
-  "personalisation": {
-    "name": "user name from a form"
-    "sign_up_link": "link generated in your system"
-  }, 
-  "sanitise_content_for": ["name"]
-}
-```
-
-Notify will sanitise the specificed placeholders, like this:
-
-```javascript
-# malicious markdown:
-name = "Anne Example, now [click this evil link](https://evil.link)"
-
-# gets sanitised to:
-"Anne Example, now \[click this evil link\]\(\)"
-
-# email will appear as:
-Anne Example, now [click this evil link]()
-```
-
-The response will include the content that we've sanitised:
-
-```javascript
-{
-  "sanitised_content": {
-    "name": {
-      "unsanitised": "Anne Example, now [click this evil link](https://evil.link)"
-      "sanitised": "Anne Example, now \[click this evil link\]\(\)\"
-    }
-  }
-}
-```
-
-##### 2. Use a backslash
-Add this in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them.
-The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
-
-#### Error codes
-
-If the request is not successful, the API returns `json` containing the relevant error code.
-To learn more about error structure, go to [Errors section](#errors).
-
-|Error message|How to fix|
-|:---|:---|
-<%= partial 'documentation/error_tables/send_an_email' %>
+2. Add a backslash in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them. The characters of most concern are those that could be used to add a link such as `[`, `]`, `(` or `)`.
 
 
 ### Send a file by email

--- a/source/ruby.html.md.erb
+++ b/source/ruby.html.md.erb
@@ -266,13 +266,69 @@ You can leave out this argument if your service only has one email reply-to addr
 
 ##### sanitise_content_for (optional)
 
-An array of personalisation placeholder keys (as strings) to sanitise when sending email. For example:
+An array of personalisation keys you want Notify to sanitise.
+See also: [Reducing the risk of malicious content injection in placeholders for more information](#reducing-the-risk-of-malicious-content-injection-in-placeholders).
+
+For all personalisation you tell us to sanitise, we will:
+
+* escape all Markdown characters
+* remove any URLs from the text
+* tell you what content we’ve sanitised
+
+For example, when you make the following API call:
 
 ```ruby
-sanitise_content_for: ["name"]
+emailresponse = client.send_email(
+  email_address: "anne.example@example.com",
+  template_id: "9d751e0e-f929-4891-82a1-a3e1c3c18ee3",
+  personalisation: {
+    name: "Anne Example, now [click this evil link](https://evil.link)",
+    sign_up_link: "link generated in your system",
+  },
+  sanitise_content_for: ["name"],
+)
 ```
 
-See [Sanitise placeholder content](#sanitise-placeholder-content).
+Notify will sanitise the content of the `name` placeholder. In the email it will appear as:
+
+```text
+Anne Example, now [click this evil link]()
+```
+
+The `"sanitised_content"` field of `response` shows how Notify has sanitised the content:
+
+```ruby
+{
+  "name" => {
+    "unsanitised" => "Anne Example, now [click this evil link](https://evil.link)",
+    "sanitised" => "Anne Example, now \\[click this evil link\\]\\(\\)"
+  }
+}
+```
+The field is empty if `sanitise_content_for` didn't change any personalisation.
+
+#### Response
+
+If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](#send-an-email-method), the object is named `emailresponse`.
+
+You can then call different methods on this object to return the requested information.
+
+|Method|Information|Type|
+|:---|:---|:---|
+|#`emailresponse.id`|Notification UUID|String|
+|#`emailresponse.reference`|`reference` argument|String|
+|#`emailresponse.content`|- `body`: Message body<br>- `subject`: Message subject<br>- `from_email`: From email address of your service found on the **Settings** page|Hash|
+|#`emailresponse.template`|Contains the `id`, `version` and `uri` of the template|Hash|
+|#`emailresponse.uri`|Notification URL|String|
+|#`emailresponse.sanitised_content`|See [`sanitise_content_for`](#sanitise-content-for-optional)|Hash|
+
+#### Error codes
+
+If the request is not successful, the client returns an error. To learn more about error structure, go to [Errors section](#errors).
+
+|Error message|How to fix|
+|:---|:---|
+<%= partial 'documentation/error_tables/ruby/send_an_email' %>
 
 #### Reducing the risk of malicious content injection in placeholders
 
@@ -289,104 +345,33 @@ The malicious content could be:
 
 An example of how malicious content can be injected into Notify personalisation:
 
-**Template in Notify**:
+Template in Notify:
 
 ```ruby
 Hello ((name))
 ```
 
-**Personalisation**: 
+Personalisation: 
 
 ```ruby
 {name: "Anne Example, now [click this evil link](https://malicious.link)"}
 ```
 
-**Email will appear as**: 
+Email will appear as: 
 
 <pre>
  <small>Dear Anne Example, now <a href="https://malicious.link>click this evil link">click this evil link</a></small>
 </pre>
 
-#### Sanitise placeholder content
+##### Sanitise placeholder content
 
 We recommend you sanitise all input from untrusted sources to prevent the injection of malicious content.
 
-To escape all Markdown characters, and remove any URL links you can:
+To escape all Markdown characters, and remove any URLs you can:
 
-##### 1. Tell us which personalisation to sanitise
-When sending emails via API, pass in the `sanitise_content_for` argument, and choose which personalisation you want to sanitise.
+1. Tell us which personalisation to sanitise by using the [`sanitise_content_for` argument](#sanitise-content-for-optional) when sending emails via API.
 
-For all personalisation you tell us to sanitise, we will:
-
-* escape all Markdown characters
-* remove any url links from the text
-* tell you what content we’ve sanitised
-
-For example, when you make the following API call:
-
-```ruby
-emailresponse = client.send_email(
-  email_address: "amalaexample@example.com",
-  template_id: "9d751e0e-f929-4891-82a1-a3e1c3c18ee3",
-  personalisation: {
-    name: "user name from a form",
-    sign_up_link: "link generated in your system",
-  },
-  sanitise_content_for: ["name"],
-)
-```
-
-Notify will sanitise the specificed placeholders, like this:
-
-```ruby
-# malicious markdown in personalisation:
-name = "Anne Example, now [click this evil link](https://evil.link)"
-
-# gets sanitised to:
-"Anne Example, now \\[click this evil link\\]\\(\\)"
-
-# email will appear as:
-Anne Example, now [click this evil link]()
-```
-
-The response includes the content that we've sanitised, which returns a hash like:
-
-```ruby
-{
-  "name" => {
-    "unsanitised" => "Anne Example, now [click this evil link](https://evil.link)",
-    "sanitised" => "Anne Example, now \\[click this evil link\\]\\(\\)"
-  }
-}
-```
-
-##### 2. Use a backslash
-
-Add this in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them.
-The characters of most concern are those that could be used to add a URL link such as `[`, `]`, `(` or `)`.
-
-#### Response
-
-If the request to the client is successful, the client returns a `Notifications::Client:ResponseNotification` object. In the example shown in the [Method section](#send-an-email-method), the object is named `emailresponse`.
-
-You can then call different methods on this object to return the requested information.
-
-|Method|Information|Type|
-|:---|:---|:---|
-|#`emailresponse.id`|Notification UUID|String|
-|#`emailresponse.reference`|`reference` argument|String|
-|#`emailresponse.content`|- `body`: Message body<br>- `subject`: Message subject<br>- `from_email`: From email address of your service found on the **Settings** page|Hash|
-|#`emailresponse.template`|Contains the `id`, `version` and `uri` of the template|Hash|
-|#`emailresponse.uri`|Notification URL|String|
-|#`emailresponse.sanitised_content`|For each sanitised placeholder, the unsanitised and sanitised values (see [Sanitise placeholder content](#sanitise-placeholder-content))|Hash|
-
-#### Error codes
-
-If the request is not successful, the client returns an error. To learn more about error structure, go to [Errors section](#errors).
-
-|Error message|How to fix|
-|:---|:---|
-<%= partial 'documentation/error_tables/ruby/send_an_email' %>
+2. Add a backslash in front of [individual Markdown characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) to escape them. The characters of most concern are those that could be used to add a link such as `[`, `]`, `(` or `)`.
 
 ### Send a file by email
 


### PR DESCRIPTION
This PR brings in improvements from https://github.com/alphagov/notifications-tech-docs/pull/339 to the remaining API docs, harmonising all the docs with one another.

It also fixes a broken Python snippet.