### PR TITLE
Update .NET client requirements

### DIFF
--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -5,7 +5,7 @@ parent: https://www.notifications.service.gov.uk/documentation
 
 # .NET client documentation
 
-This documentation is for developers interested in using the GOV.UK Notify .NET client to send emails (including documents), text messages or letters. GOV.UK Notify supports .NET (Core) 10.0.0 or later. .NET Framework is no longer supported.
+This documentation is for developers interested in using the GOV.UK Notify .NET client to send emails (including documents), text messages or letters. GOV.UK Notify supports .NET (Core) 10.0.0 or later. We no longer support .NET Framework.
 
 ## Set up the client
 

--- a/source/net.html.md.erb
+++ b/source/net.html.md.erb
@@ -5,7 +5,7 @@ parent: https://www.notifications.service.gov.uk/documentation
 
 # .NET client documentation
 
-This documentation is for developers interested in using the GOV.UK Notify .NET client to send emails (including documents), text messages or letters. GOV.UK Notify supports .NET framework 4.6.2 and .NET Core 2.0.
+This documentation is for developers interested in using the GOV.UK Notify .NET client to send emails (including documents), text messages or letters. GOV.UK Notify supports .NET (Core) 10.0.0 or later. .NET Framework is no longer supported.
 
 ## Set up the client
 


### PR DESCRIPTION
Since 8.0.0 we no longer support .NET Framework, nor any version of .NET Core prior to 10.0.0. https://github.com/alphagov/notifications-net-client/blob/main/CHANGELOG.md

.NET Core is usually just referred to as ".NET" now, but I've left Core in brackets for clarity.